### PR TITLE
Stabilize desktop layout and media loading

### DIFF
--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -31,7 +31,7 @@ describe("App routing", () => {
     expect(topBar).toBeInTheDocument();
     expect(searchLink).toHaveAttribute("aria-current", "page");
     expect(await screen.findByRole("heading", { name: "Search" })).toBeInTheDocument();
-    expect(screen.getByText("Enterprise v3.0")).toBeInTheDocument();
+    expect(screen.queryByText("Enterprise v3.0")).not.toBeInTheDocument();
     expect(screen.getByRole("button", { name: /switch to light theme/i })).toBeInTheDocument();
   });
 });

--- a/src/application/search/search-service.test.ts
+++ b/src/application/search/search-service.test.ts
@@ -81,4 +81,13 @@ describe("search-service", () => {
 
     expect(searchWallpapersInRepository).toHaveBeenCalledWith({ q: "cats", page: 3 }, "");
   });
+
+  it("keeps search working when key storage is unavailable", async () => {
+    vi.mocked(loadStoredWallhavenKey).mockRejectedValue(new Error("store unavailable"));
+    vi.mocked(searchWallpapersInRepository).mockResolvedValue(sampleResult);
+
+    await searchWallpapers({ q: "mountains", page: 1 });
+
+    expect(searchWallpapersInRepository).toHaveBeenCalledWith({ q: "mountains", page: 1 }, "");
+  });
 });

--- a/src/application/search/search-service.ts
+++ b/src/application/search/search-service.ts
@@ -3,6 +3,6 @@ import { loadStoredWallhavenKey } from "@/infrastructure/tauri/settings-reposito
 import { searchWallpapers as searchWallpapersInRepository } from "@/infrastructure/tauri/search-repository";
 
 export async function searchWallpapers(filters: WallhavenQueryFilters) {
-  const wallhavenKey = await loadStoredWallhavenKey();
+  const wallhavenKey = await loadStoredWallhavenKey().catch(() => "");
   return searchWallpapersInRepository(filters, wallhavenKey);
 }

--- a/src/application/settings/settings-service.test.ts
+++ b/src/application/settings/settings-service.test.ts
@@ -1,4 +1,10 @@
 vi.mock("@/infrastructure/tauri/settings-repository", () => ({
+  defaultSettingsPreferences: {
+    launchAtLogin: false,
+    confirmBeforeDelete: true,
+    telemetryEnabled: false,
+    cacheSizeBytes: 38_400_000,
+  },
   loadStoredWallhavenKey: vi.fn(),
   saveStoredWallhavenKey: vi.fn(),
   loadDownloadDirectorySettings: vi.fn(),
@@ -77,7 +83,7 @@ describe("settings-service", () => {
     await expect(loadSettings()).rejects.toThrow("download directory unavailable");
   });
 
-  it("still fails when the stored key cannot be loaded", async () => {
+  it("keeps loading settings when optional stored values are unavailable", async () => {
     vi.mocked(loadStoredWallhavenKey).mockRejectedValue(new Error("key load failed"));
     vi.mocked(loadDownloadDirectorySettings).mockResolvedValue({
       customDirectoryPath: "",
@@ -87,9 +93,22 @@ describe("settings-service", () => {
         "/Users/test/Library/Application Support/cc.zhengyh.wallhaven.desktop/wallpapers",
       isUsingDefaultDirectory: true,
     });
-    vi.mocked(loadNetworkProxySettings).mockResolvedValue(null);
+    vi.mocked(loadNetworkProxySettings).mockRejectedValue(new Error("proxy decode failed"));
+    vi.mocked(loadUserPreferences).mockRejectedValue(new Error("preferences load failed"));
 
-    await expect(loadSettings()).rejects.toThrow("key load failed");
+    await expect(loadSettings()).resolves.toEqual({
+      wallhavenKey: "",
+      downloadDirectory: {
+        customDirectoryPath: "",
+        effectiveDirectoryPath:
+          "/Users/test/Library/Application Support/cc.zhengyh.wallhaven.desktop/wallpapers",
+        defaultDirectoryPath:
+          "/Users/test/Library/Application Support/cc.zhengyh.wallhaven.desktop/wallpapers",
+        isUsingDefaultDirectory: true,
+      },
+      networkProxy: null,
+      preferences,
+    });
   });
 
   it("persists the stored key, custom download directory, and network proxy through saveSettings", async () => {

--- a/src/application/settings/settings-service.ts
+++ b/src/application/settings/settings-service.ts
@@ -1,4 +1,5 @@
 import {
+  defaultSettingsPreferences,
   loadDownloadDirectorySettings,
   loadNetworkProxySettings,
   loadStoredWallhavenKey,
@@ -16,12 +17,20 @@ import type {
   SettingsSnapshot,
 } from "./settings.types";
 
+async function loadOptionalSetting<T>(loader: () => Promise<T>, fallback: T): Promise<T> {
+  try {
+    return await loader();
+  } catch {
+    return fallback;
+  }
+}
+
 export async function loadSettings(): Promise<SettingsSnapshot> {
-  const [wallhavenKey, downloadDirectory, networkProxy, preferences] = await Promise.all([
-    loadStoredWallhavenKey(),
+  const [downloadDirectory, wallhavenKey, networkProxy, preferences] = await Promise.all([
     loadDownloadDirectorySettings(),
-    loadNetworkProxySettings(),
-    loadUserPreferencesFromRepository(),
+    loadOptionalSetting(loadStoredWallhavenKey, ""),
+    loadOptionalSetting(loadNetworkProxySettings, null),
+    loadOptionalSetting(loadUserPreferencesFromRepository, defaultSettingsPreferences),
   ]);
 
   return {

--- a/src/components/app-shell.tsx
+++ b/src/components/app-shell.tsx
@@ -1,7 +1,7 @@
 import { Outlet } from "react-router-dom";
 
-import { Sidebar } from "@/components/sidebar";
 import { MacWindowChrome } from "@/components/mac-window-chrome";
+import { Sidebar } from "@/components/sidebar";
 
 export function AppShell() {
   return (

--- a/src/components/mac-window-chrome.tsx
+++ b/src/components/mac-window-chrome.tsx
@@ -5,15 +5,7 @@ import { ThemeToggle } from "@/components/theme-toggle";
 export function MacWindowChrome() {
   return (
     <header aria-label="top bar" className="wh-window-chrome">
-      <div className="flex items-center gap-2">
-        <span aria-hidden="true" className="h-3 w-3 rounded-full bg-[#ff5f57]" />
-        <span aria-hidden="true" className="h-3 w-3 rounded-full bg-[#febc2e]" />
-        <span aria-hidden="true" className="h-3 w-3 rounded-full bg-[#28c840]" />
-        <div className="ml-1">
-          <h1 className="text-[16px] font-semibold leading-5 text-foreground">Wallhaven Desktop</h1>
-          <p className="text-[10px] font-medium leading-4 text-muted-foreground">Enterprise v3.0</p>
-        </div>
-      </div>
+      <div aria-hidden="true" />
 
       <div className="flex items-center gap-2">
         <button aria-label="Keyboard shortcuts" className="wh-chrome-button" type="button">

--- a/src/components/page-heading.tsx
+++ b/src/components/page-heading.tsx
@@ -7,12 +7,12 @@ type PageHeadingProps = {
 
 export function PageHeading({ eyebrow, title, description, badge }: PageHeadingProps) {
   return (
-    <div className="flex h-12 flex-wrap items-center gap-x-4 gap-y-2">
+    <div className="flex min-h-12 flex-wrap items-center gap-x-4 gap-y-2">
       <p className="sr-only">{eyebrow}</p>
       <h2 className="text-[28px] font-semibold leading-[34px] tracking-normal text-foreground">{title}</h2>
       <p className="text-[14px] font-medium text-muted-foreground">{description}</p>
       {badge ? (
-        <div className="wh-soft-success ml-auto inline-flex h-8 min-w-[176px] items-center justify-center gap-2 rounded-full px-4 text-[12px] font-semibold">
+        <div className="wh-soft-success inline-flex h-8 min-w-[176px] items-center justify-center gap-2 rounded-full px-4 text-[12px] font-semibold sm:ml-auto">
           <span className="h-2 w-2 rounded-full bg-emerald-400" />
           {badge}
         </div>

--- a/src/components/proxied-image.test.tsx
+++ b/src/components/proxied-image.test.tsx
@@ -1,0 +1,61 @@
+vi.mock("@/infrastructure/tauri/media-repository", () => ({
+  loadRemoteImageObjectUrl: vi.fn(),
+}));
+
+import { render, screen, waitFor } from "@testing-library/react";
+
+import { loadRemoteImageObjectUrl } from "@/infrastructure/tauri/media-repository";
+
+import { ProxiedImage } from "./proxied-image";
+
+describe("ProxiedImage", () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    Object.defineProperty(URL, "revokeObjectURL", {
+      configurable: true,
+      value: vi.fn(),
+    });
+  });
+
+  it("does not expose the remote image URL while the proxy load is pending", () => {
+    vi.mocked(loadRemoteImageObjectUrl).mockReturnValue(new Promise(() => undefined));
+
+    render(<ProxiedImage alt="wallpaper" src="https://th.wallhaven.cc/lg/kx/kxpkmm.jpg" />);
+
+    expect(screen.getByRole("img", { name: "wallpaper" }).getAttribute("src")).toMatch(
+      /^data:image\/svg\+xml/,
+    );
+    expect(loadRemoteImageObjectUrl).toHaveBeenCalledWith(
+      "https://th.wallhaven.cc/lg/kx/kxpkmm.jpg",
+    );
+  });
+
+  it("renders the object URL returned by the Tauri proxy loader", async () => {
+    vi.mocked(loadRemoteImageObjectUrl).mockResolvedValue("blob://proxied-wallpaper");
+
+    render(<ProxiedImage alt="wallpaper" src="https://th.wallhaven.cc/lg/kx/kxpkmm.jpg" />);
+
+    await waitFor(() => {
+      expect(screen.getByRole("img", { name: "wallpaper" })).toHaveAttribute(
+        "src",
+        "blob://proxied-wallpaper",
+      );
+    });
+  });
+
+  it("keeps a non-broken placeholder when proxy loading fails", async () => {
+    vi.mocked(loadRemoteImageObjectUrl).mockRejectedValue(new Error("network unavailable"));
+
+    render(<ProxiedImage alt="wallpaper" src="https://th.wallhaven.cc/lg/kx/kxpkmm.jpg" />);
+
+    await waitFor(() => {
+      expect(screen.getByRole("img", { name: "wallpaper" })).toHaveAttribute(
+        "data-load-state",
+        "error",
+      );
+    });
+    expect(screen.getByRole("img", { name: "wallpaper" }).getAttribute("src")).toMatch(
+      /^data:image\/svg\+xml/,
+    );
+  });
+});

--- a/src/components/proxied-image.tsx
+++ b/src/components/proxied-image.tsx
@@ -1,4 +1,4 @@
-import type { ImgHTMLAttributes } from "react"
+import type { ImgHTMLAttributes, SyntheticEvent } from "react"
 import { useEffect, useState } from "react"
 
 import { loadRemoteImageObjectUrl } from "@/infrastructure/tauri/media-repository"
@@ -7,26 +7,33 @@ type ProxiedImageProps = Omit<ImgHTMLAttributes<HTMLImageElement>, "src"> & {
   src: string
 }
 
-export function ProxiedImage({ src, alt, ...props }: ProxiedImageProps) {
-  const [resolvedSrc, setResolvedSrc] = useState<string | null>(null)
+const imagePlaceholderSrc =
+  "data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 9'%3E%3Crect width='16' height='9' fill='%23101b2a'/%3E%3C/svg%3E"
+
+export function ProxiedImage({ src, alt, onError, ...props }: ProxiedImageProps) {
+  const [resolvedSrc, setResolvedSrc] = useState(imagePlaceholderSrc)
+  const [loadState, setLoadState] = useState<"loading" | "loaded" | "error">("loading")
 
   useEffect(() => {
     let isActive = true
     let objectUrl: string | null = null
 
-    setResolvedSrc(null)
+    setResolvedSrc(imagePlaceholderSrc)
+    setLoadState("loading")
     loadRemoteImageObjectUrl(src)
       .then((nextObjectUrl) => {
         objectUrl = nextObjectUrl
         if (isActive) {
           setResolvedSrc(nextObjectUrl)
+          setLoadState("loaded")
         } else {
           URL.revokeObjectURL(nextObjectUrl)
         }
       })
       .catch(() => {
         if (isActive) {
-          setResolvedSrc(src)
+          setResolvedSrc(imagePlaceholderSrc)
+          setLoadState("error")
         }
       })
 
@@ -38,5 +45,22 @@ export function ProxiedImage({ src, alt, ...props }: ProxiedImageProps) {
     }
   }, [src])
 
-  return <img {...props} alt={alt} src={resolvedSrc ?? src} />
+  const handleImageError = (event: SyntheticEvent<HTMLImageElement, Event>) => {
+    if (resolvedSrc !== imagePlaceholderSrc) {
+      setResolvedSrc(imagePlaceholderSrc)
+      setLoadState("error")
+    }
+
+    onError?.(event)
+  }
+
+  return (
+    <img
+      {...props}
+      alt={alt}
+      data-load-state={loadState}
+      onError={handleImageError}
+      src={resolvedSrc}
+    />
+  )
 }

--- a/src/features/gallery/GalleryPage.test.tsx
+++ b/src/features/gallery/GalleryPage.test.tsx
@@ -157,14 +157,25 @@ describe("GalleryPage", () => {
     expect(screen.getByRole("button", { name: /Favorites/i })).toBeInTheDocument()
   })
 
+  it("defaults the gallery archive to SFW wallpapers", async () => {
+    vi.mocked(loadInitialGalleryItems).mockResolvedValue(sampleResponse)
+
+    render(<GalleryPage />)
+
+    expect(await screen.findByRole("button", { name: "SFW", pressed: true })).toBeInTheDocument()
+    expect(screen.getAllByText("wallhaven-kxpkmm.jpg").length).toBeGreaterThan(0)
+    expect(screen.queryByText("forest-scene.png")).not.toBeInTheDocument()
+  })
+
   it("filters the loaded archive locally from the gallery toolbar", async () => {
     vi.mocked(loadInitialGalleryItems).mockResolvedValue(sampleResponse)
 
     render(<GalleryPage />)
 
     const user = userEvent.setup()
+    await user.click(await screen.findByRole("button", { name: "All" }))
     await user.type(
-      await screen.findByRole("searchbox", { name: /Search local gallery/i }),
+      screen.getByRole("searchbox", { name: /Search local gallery/i }),
       "forest",
     )
 

--- a/src/features/gallery/GalleryPage.tsx
+++ b/src/features/gallery/GalleryPage.tsx
@@ -114,7 +114,7 @@ export function GalleryPage() {
   const [isLoading, setIsLoading] = useState(true)
   const [loadError, setLoadError] = useState<string | null>(null)
   const [localQuery, setLocalQuery] = useState("")
-  const [activeChip, setActiveChip] = useState<(typeof filterChips)[number]>("All")
+  const [activeChip, setActiveChip] = useState<(typeof filterChips)[number]>("SFW")
   const [selectedWallpaperId, setSelectedWallpaperId] = useState<string | null>(null)
   const [tagDraft, setTagDraft] = useState("")
   const [pendingAction, setPendingAction] = useState<string | null>(null)

--- a/src/features/search/SearchPage.tsx
+++ b/src/features/search/SearchPage.tsx
@@ -583,104 +583,104 @@ export function SearchPage() {
         title="Search"
       />
 
-      <div className="grid grid-cols-[minmax(820px,1fr)_260px] items-start gap-[26px]">
+      <div className="grid grid-cols-1 items-start gap-[22px] min-[1180px]:grid-cols-[minmax(0,1fr)_260px] min-[1440px]:gap-[26px]">
         <div className="min-w-0 space-y-6">
           <section aria-label="Search filters">
-          <form className="space-y-4" onSubmit={onSubmit}>
-            <div className="grid grid-cols-[1fr_122px] gap-[18px]">
-              <label className="relative block" htmlFor="search-query">
-                <SearchIcon className="pointer-events-none absolute left-5 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
-                <input
-                  aria-invalid={formState.errors.q ? true : undefined}
-                  aria-label="关键词"
-                  className="wh-control h-[42px] w-full pl-12 pr-4 text-[13px]"
-                  id="search-query"
-                  placeholder="Search for wallpapers  (e.g. mountains, anime, space...)"
-                  {...register("q")}
-                />
-              </label>
-              <Button
-                aria-label="搜索"
-                className="h-[42px] rounded-[14px] text-[14px]"
-                disabled={formState.isSubmitting || isBulkDownloading}
-                type="submit"
-              >
-                {formState.isSubmitting ? <Loader2 className="h-4 w-4 animate-spin" /> : null}
-                Search
-              </Button>
-            </div>
-
-            {formState.errors.q ? (
-              <p className="-mt-2 text-[12px] text-destructive" role="alert">
-                {formState.errors.q.message}
-              </p>
-            ) : null}
-
-            <div className="grid grid-cols-[repeat(5,1fr)_142px] gap-[12px]">
-              <label className="wh-control flex h-[54px] flex-col justify-center px-4" htmlFor="search-category">
-                <span className="text-[9px] font-semibold uppercase leading-4 text-muted-foreground">Category</span>
-                <select aria-label="分类" className="bg-transparent text-[13px] font-semibold outline-none" id="search-category" {...register("category")}>
-                  <option value="all">All</option>
-                  <option value="general">General</option>
-                  <option value="anime">Anime</option>
-                  <option value="people">People</option>
-                  <option value="ga">General + Anime</option>
-                  <option value="gp">General + People</option>
-                </select>
-              </label>
-              <label className="wh-control flex h-[54px] flex-col justify-center px-4" htmlFor="search-purity">
-                <span className="text-[9px] font-semibold uppercase leading-4 text-muted-foreground">Purity</span>
-                <select aria-label="纯净度" className="bg-transparent text-[13px] font-semibold outline-none" id="search-purity" {...register("purityPreset")}>
-                  <option value="sfw">SFW</option>
-                  <option value="sketchy">Sketchy</option>
-                  <option value="nsfw">NSFW</option>
-                  <option value="ws">SFW + Sketchy</option>
-                  <option value="wn">SFW + NSFW</option>
-                  <option value="sn">Sketchy + NSFW</option>
-                  <option value="all">All purity levels</option>
-                </select>
-              </label>
-              <label className="wh-control flex h-[54px] flex-col justify-center px-4" htmlFor="search-sorting">
-                <span className="text-[9px] font-semibold uppercase leading-4 text-muted-foreground">Sorting</span>
-                <select aria-label="排序" className="bg-transparent text-[13px] font-semibold outline-none" id="search-sorting" {...register("sorting")}>
-                  <option value="date_added">Date added</option>
-                  <option value="toplist">Toplist</option>
-                </select>
-              </label>
-              <div className="wh-control flex h-[54px] flex-col justify-center px-4" aria-label="Resolution">
-                <span className="text-[9px] font-semibold uppercase leading-4 text-muted-foreground">Resolution</span>
-                <span className="text-[13px] font-semibold">All</span>
+            <form className="space-y-4" onSubmit={onSubmit}>
+              <div className="grid grid-cols-1 gap-[12px] sm:grid-cols-[minmax(0,1fr)_122px] sm:gap-[18px]">
+                <label className="relative block" htmlFor="search-query">
+                  <SearchIcon className="pointer-events-none absolute left-5 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
+                  <input
+                    aria-invalid={formState.errors.q ? true : undefined}
+                    aria-label="关键词"
+                    className="wh-control h-[42px] w-full pl-12 pr-4 text-[13px]"
+                    id="search-query"
+                    placeholder="Search for wallpapers  (e.g. mountains, anime, space...)"
+                    {...register("q")}
+                  />
+                </label>
+                <Button
+                  aria-label="搜索"
+                  className="h-[42px] rounded-[14px] text-[14px]"
+                  disabled={formState.isSubmitting || isBulkDownloading}
+                  type="submit"
+                >
+                  {formState.isSubmitting ? <Loader2 className="h-4 w-4 animate-spin" /> : null}
+                  Search
+                </Button>
               </div>
-              <div className="wh-control flex h-[54px] flex-col justify-center px-4" aria-label="Aspect Ratio">
-                <span className="text-[9px] font-semibold uppercase leading-4 text-muted-foreground">Aspect Ratio</span>
-                <span className="text-[13px] font-semibold">16:9</span>
+
+              {formState.errors.q ? (
+                <p className="-mt-2 text-[12px] text-destructive" role="alert">
+                  {formState.errors.q.message}
+                </p>
+              ) : null}
+
+              <div className="grid grid-cols-1 gap-[12px] sm:grid-cols-2 lg:grid-cols-3 min-[1500px]:grid-cols-[repeat(5,minmax(0,1fr))_142px]">
+                <label className="wh-control flex h-[54px] flex-col justify-center px-4" htmlFor="search-category">
+                  <span className="text-[9px] font-semibold uppercase leading-4 text-muted-foreground">Category</span>
+                  <select aria-label="分类" className="bg-transparent text-[13px] font-semibold outline-none" id="search-category" {...register("category")}>
+                    <option value="all">All</option>
+                    <option value="general">General</option>
+                    <option value="anime">Anime</option>
+                    <option value="people">People</option>
+                    <option value="ga">General + Anime</option>
+                    <option value="gp">General + People</option>
+                  </select>
+                </label>
+                <label className="wh-control flex h-[54px] flex-col justify-center px-4" htmlFor="search-purity">
+                  <span className="text-[9px] font-semibold uppercase leading-4 text-muted-foreground">Purity</span>
+                  <select aria-label="纯净度" className="bg-transparent text-[13px] font-semibold outline-none" id="search-purity" {...register("purityPreset")}>
+                    <option value="sfw">SFW</option>
+                    <option value="sketchy">Sketchy</option>
+                    <option value="nsfw">NSFW</option>
+                    <option value="ws">SFW + Sketchy</option>
+                    <option value="wn">SFW + NSFW</option>
+                    <option value="sn">Sketchy + NSFW</option>
+                    <option value="all">All purity levels</option>
+                  </select>
+                </label>
+                <label className="wh-control flex h-[54px] flex-col justify-center px-4" htmlFor="search-sorting">
+                  <span className="text-[9px] font-semibold uppercase leading-4 text-muted-foreground">Sorting</span>
+                  <select aria-label="排序" className="bg-transparent text-[13px] font-semibold outline-none" id="search-sorting" {...register("sorting")}>
+                    <option value="date_added">Date added</option>
+                    <option value="toplist">Toplist</option>
+                  </select>
+                </label>
+                <div className="wh-control flex h-[54px] flex-col justify-center px-4" aria-label="Resolution">
+                  <span className="text-[9px] font-semibold uppercase leading-4 text-muted-foreground">Resolution</span>
+                  <span className="text-[13px] font-semibold">All</span>
+                </div>
+                <div className="wh-control flex h-[54px] flex-col justify-center px-4" aria-label="Aspect Ratio">
+                  <span className="text-[9px] font-semibold uppercase leading-4 text-muted-foreground">Aspect Ratio</span>
+                  <span className="text-[13px] font-semibold">16:9</span>
+                </div>
+                <label className="wh-control flex h-[54px] flex-col justify-center px-4" htmlFor="search-top-range">
+                  <span className="text-[9px] font-semibold uppercase leading-4 text-muted-foreground">More Filters</span>
+                  <span className="flex items-center justify-between gap-3">
+                    {formValues.sorting === "toplist" ? (
+                      <select aria-label="热榜范围" className="min-w-0 bg-transparent text-[13px] font-semibold outline-none" id="search-top-range" {...register("topRange")}>
+                        <option value="1M">Advanced</option>
+                        <option value="1d">Past day</option>
+                        <option value="3d">Past 3 days</option>
+                        <option value="1w">Past week</option>
+                        <option value="3M">Past 3 months</option>
+                        <option value="6M">Past 6 months</option>
+                        <option value="1y">Past year</option>
+                      </select>
+                    ) : (
+                      <span className="text-[13px] font-semibold">Advanced</span>
+                    )}
+                    <SlidersHorizontal className="h-4 w-4 shrink-0 text-primary" />
+                  </span>
+                </label>
               </div>
-              <label className="wh-control flex h-[54px] flex-col justify-center px-4" htmlFor="search-top-range">
-                <span className="text-[9px] font-semibold uppercase leading-4 text-muted-foreground">More Filters</span>
-                <span className="flex items-center justify-between gap-3">
-                  {formValues.sorting === "toplist" ? (
-                    <select aria-label="热榜范围" className="min-w-0 bg-transparent text-[13px] font-semibold outline-none" id="search-top-range" {...register("topRange")}>
-                      <option value="1M">Advanced</option>
-                      <option value="1d">Past day</option>
-                      <option value="3d">Past 3 days</option>
-                      <option value="1w">Past week</option>
-                      <option value="3M">Past 3 months</option>
-                      <option value="6M">Past 6 months</option>
-                      <option value="1y">Past year</option>
-                    </select>
-                  ) : (
-                    <span className="text-[13px] font-semibold">Advanced</span>
-                  )}
-                  <SlidersHorizontal className="h-4 w-4 shrink-0 text-primary" />
-                </span>
-              </label>
-            </div>
-          </form>
+            </form>
           </section>
 
           <section aria-label="Search results" className="space-y-4">
-            <div className="flex h-[42px] items-center justify-between">
-              <div className="flex items-center gap-4">
+            <div className="flex min-h-[42px] flex-wrap items-center justify-between gap-3">
+              <div className="flex min-w-0 flex-wrap items-center gap-x-4 gap-y-1">
                 <h3 className="text-[14px] font-semibold text-foreground">
                   {resultSummaryLabel ?? "Start with a query"}
                 </h3>
@@ -691,7 +691,7 @@ export function SearchPage() {
                 ) : null}
               </div>
               {result && result.data.length > 0 ? (
-                <div className="flex items-center gap-3">
+                <div className="flex flex-wrap items-center justify-end gap-3">
                   <Button
                     aria-label={bulkDownloadLabel}
                     className="h-[42px] rounded-[14px] px-4"
@@ -735,7 +735,7 @@ export function SearchPage() {
             ) : null}
 
             {formState.isSubmitting ? (
-              <div className="grid grid-cols-3 gap-[18px]" aria-label="Loading search results">
+              <div className="grid grid-cols-1 gap-[18px] sm:grid-cols-2 xl:grid-cols-3" aria-label="Loading search results">
                 {Array.from({ length: 9 }, (_, index) => (
                   <div className="h-[156px] animate-pulse rounded-2xl border border-border bg-[var(--surface-deep)]" key={index} />
                 ))}
@@ -768,7 +768,7 @@ export function SearchPage() {
           </section>
         </div>
 
-        <aside className="app-panel min-h-[716px] space-y-6 p-6" aria-label="Inspector">
+        <aside className="app-panel space-y-6 p-6 min-[1180px]:min-h-[600px]" aria-label="Inspector">
           <div className="space-y-2">
             <h3 className="text-[20px] font-semibold leading-7 text-foreground">Inspector</h3>
             <p className="text-[13px] font-medium text-muted-foreground">

--- a/src/features/search/components/SearchResultGrid.test.tsx
+++ b/src/features/search/components/SearchResultGrid.test.tsx
@@ -3,10 +3,15 @@ vi.mock("yet-another-react-lightbox", () => ({
     open ? <div data-testid="lightbox">{slides[index]?.src}</div> : null,
 }));
 
-import { render, screen } from "@testing-library/react";
+vi.mock("@/infrastructure/tauri/media-repository", () => ({
+  loadRemoteImageObjectUrl: vi.fn(),
+}));
+
+import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 
 import type { SearchWallpaper } from "@/application/search/search.types";
+import { loadRemoteImageObjectUrl } from "@/infrastructure/tauri/media-repository";
 
 import { SearchResultGrid } from "./SearchResultGrid";
 
@@ -38,13 +43,26 @@ const wallpapers: SearchWallpaper[] = [
 ];
 
 describe("SearchResultGrid", () => {
-  it("renders thumbnail cards with key metadata", () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    Object.defineProperty(URL, "revokeObjectURL", {
+      configurable: true,
+      value: vi.fn(),
+    });
+  });
+
+  it("renders thumbnail cards with key metadata through the proxy loader", async () => {
+    vi.mocked(loadRemoteImageObjectUrl).mockResolvedValue("blob://proxied-thumbnail");
+
     render(<SearchResultGrid wallpapers={wallpapers} />);
 
-    expect(screen.getByRole("img", { name: /Wallpaper kxpkmm/i })).toHaveAttribute(
-      "src",
-      "https://th.wallhaven.cc/lg/kx/kxpkmm.jpg",
-    );
+    await waitFor(() => {
+      expect(screen.getByRole("img", { name: /Wallpaper kxpkmm/i })).toHaveAttribute(
+        "src",
+        "blob://proxied-thumbnail",
+      );
+    });
+    expect(loadRemoteImageObjectUrl).toHaveBeenCalledWith("https://th.wallhaven.cc/lg/kx/kxpkmm.jpg");
     expect(screen.getByText("1966x3000")).toBeInTheDocument();
     expect(screen.getByText("79")).toBeInTheDocument();
     expect(screen.getByText("2572")).toBeInTheDocument();
@@ -53,6 +71,8 @@ describe("SearchResultGrid", () => {
   });
 
   it("opens a preview lightbox for the selected wallpaper", async () => {
+    vi.mocked(loadRemoteImageObjectUrl).mockResolvedValue("blob://proxied-thumbnail");
+
     render(<SearchResultGrid wallpapers={wallpapers} />);
 
     const user = userEvent.setup();

--- a/src/features/search/components/WallpaperGrid.tsx
+++ b/src/features/search/components/WallpaperGrid.tsx
@@ -30,7 +30,7 @@ export function WallpaperGrid({
   return (
     <>
       <div
-        className="grid max-h-[calc(100vh-282px)] grid-cols-[repeat(auto-fill,minmax(270px,1fr))] gap-[18px] overflow-y-auto pr-1"
+        className="grid max-h-none grid-cols-[repeat(auto-fill,minmax(min(100%,270px),1fr))] gap-[18px] overflow-visible pr-1 min-[1180px]:max-h-[calc(100vh-282px)] min-[1180px]:overflow-y-auto"
         style={{ contentVisibility: "auto", containIntrinsicSize: "932px 618px" }}
       >
         {wallpapers.map((wallpaper, index) => (

--- a/src/features/settings/SettingsPage.tsx
+++ b/src/features/settings/SettingsPage.tsx
@@ -427,8 +427,8 @@ export function SettingsPage() {
         title="Settings"
       />
 
-      <div className="grid grid-cols-[minmax(686px,1fr)_452px] items-start gap-[30px]">
-        <form className="app-panel min-h-[698px] space-y-6 p-[30px]" onSubmit={onSubmit}>
+      <div className="grid grid-cols-1 items-start gap-[22px] min-[1280px]:grid-cols-[minmax(0,1fr)_minmax(320px,452px)] min-[1440px]:gap-[30px]">
+        <form className="app-panel min-h-0 space-y-6 p-5 min-[900px]:p-[30px] min-[1280px]:min-h-[640px]" onSubmit={onSubmit}>
           <section aria-labelledby="wallhaven-access-heading" className="space-y-4">
             <div>
               <h3 className="text-[20px] font-semibold leading-7 text-foreground" id="wallhaven-access-heading">
@@ -439,7 +439,7 @@ export function SettingsPage() {
               </p>
             </div>
 
-            <div className="grid grid-cols-[124px_minmax(0,1fr)] items-center gap-4">
+            <div className="grid grid-cols-1 items-center gap-3 md:grid-cols-[124px_minmax(0,1fr)] md:gap-4">
               <label className="text-[13px] font-semibold text-foreground" htmlFor="wallhavenKey">
                 API Key
               </label>
@@ -476,7 +476,7 @@ export function SettingsPage() {
             </div>
             <p
               aria-live="polite"
-              className={cn("pl-[140px] text-[12px]", apiKeyStatus?.tone === "error" ? "text-destructive" : "text-muted-foreground")}
+              className={cn("text-[12px] md:pl-[140px]", apiKeyStatus?.tone === "error" ? "text-destructive" : "text-muted-foreground")}
             >
               {apiKeyStatus?.message ?? "Empty value clears the local key. Full key is never written to UI logs."}
             </p>
@@ -492,7 +492,7 @@ export function SettingsPage() {
               </p>
             </div>
 
-            <div className="grid grid-cols-[124px_minmax(0,1fr)_96px] items-center gap-4">
+            <div className="grid grid-cols-1 items-center gap-3 md:grid-cols-[124px_minmax(0,1fr)_96px] md:gap-4">
               <label className="text-[13px] font-semibold text-foreground" htmlFor="customDownloadDirectoryPath">
                 Download path
               </label>
@@ -520,11 +520,11 @@ export function SettingsPage() {
               </Button>
             </div>
             {directoryError ? (
-              <p className="pl-[140px] text-[12px] text-destructive" role="alert">
+              <p className="text-[12px] text-destructive md:pl-[140px]" role="alert">
                 {directoryError}
               </p>
             ) : null}
-            <div className="pl-[140px]">
+            <div className="md:pl-[140px]">
               <Button
                 className="h-10 rounded-[14px]"
                 disabled={isLoading}
@@ -551,7 +551,7 @@ export function SettingsPage() {
               </p>
             </div>
 
-            <div className="grid grid-cols-[124px_194px_minmax(0,1fr)_116px] items-center gap-4">
+            <div className="grid grid-cols-1 items-center gap-3 md:grid-cols-[124px_194px_minmax(0,1fr)_116px] md:gap-4">
               <span className="text-[13px] font-semibold text-foreground">Protocol</span>
               <div className="wh-control grid h-[42px] grid-cols-2 overflow-hidden p-0">
                 {proxyOptions.map((option) => (
@@ -591,7 +591,7 @@ export function SettingsPage() {
             </div>
             <p
               aria-live="polite"
-              className={cn("pl-[140px] text-[12px]", proxyAddressError || proxyStatus?.tone === "error" ? "text-destructive" : "text-muted-foreground")}
+              className={cn("text-[12px] md:pl-[140px]", proxyAddressError || proxyStatus?.tone === "error" ? "text-destructive" : "text-muted-foreground")}
               role={proxyAddressError ? "alert" : undefined}
             >
               {proxyAddressError ?? proxyStatus?.message ?? "Proxy validation runs before future Search and Download requests use this setting."}
@@ -612,7 +612,7 @@ export function SettingsPage() {
               </Button>
             </div>
 
-            <div className="grid grid-cols-3 gap-3">
+            <div className="grid grid-cols-1 gap-3 lg:grid-cols-3">
               <Toggle
                 checked={preferences.launchAtLogin}
                 description="Apply on next app launch"
@@ -636,7 +636,7 @@ export function SettingsPage() {
 
           {loadError ? <ErrorState message={loadError} /> : null}
 
-          <div className="flex h-[64px] items-center justify-between rounded-[16px] border border-border bg-[var(--surface-deep)] px-5">
+          <div className="flex min-h-[64px] flex-wrap items-center justify-between gap-3 rounded-[16px] border border-border bg-[var(--surface-deep)] px-5 py-3">
             <p
               aria-live="polite"
               className={cn(
@@ -653,7 +653,7 @@ export function SettingsPage() {
           </div>
         </form>
 
-        <aside aria-label="Effective destination" className="app-panel min-h-[698px] p-[30px]">
+        <aside aria-label="Effective destination" className="app-panel min-h-0 p-5 min-[900px]:p-[30px] min-[1280px]:min-h-[640px]">
           {!downloadDirectory && !loadError ? <LoadingSkeleton label="Loading storage details..." /> : null}
           {!downloadDirectory && loadError ? (
             <ErrorState message="Settings failed to load, so storage summary is unavailable." title="Storage unavailable" />

--- a/src/infrastructure/tauri/settings-repository.test.ts
+++ b/src/infrastructure/tauri/settings-repository.test.ts
@@ -90,6 +90,16 @@ describe("settings-repository", () => {
     expect(store.close).toHaveBeenCalledTimes(1);
   });
 
+  it("does not fail completed reads when releasing the store resource fails", async () => {
+    const store = createMockStore();
+    store.get.mockResolvedValue("stored-key");
+    store.close.mockRejectedValue(new Error("close failed"));
+    vi.mocked(Store.load).mockResolvedValue(store as never);
+
+    await expect(loadStoredWallhavenKey()).resolves.toBe("stored-key");
+    expect(store.close).toHaveBeenCalledTimes(1);
+  });
+
   it("invokes the Rust download directory settings command by name", async () => {
     vi.mocked(invoke).mockResolvedValue({
       customDirectoryPath: "/Users/test/Pictures/Wallhaven",

--- a/src/infrastructure/tauri/settings-repository.ts
+++ b/src/infrastructure/tauri/settings-repository.ts
@@ -21,12 +21,19 @@ export const defaultSettingsPreferences: SettingsPreferences = {
 
 async function withSettingsStore<T>(callback: (store: Store) => Promise<T>): Promise<T> {
   const store = await Store.load(SETTINGS_STORE_PATH);
+  let result!: T;
 
   try {
-    return await callback(store);
+    result = await callback(store);
   } finally {
-    await store.close();
+    try {
+      await store.close();
+    } catch {
+      // Closing releases a Tauri resource, but a close failure should not invalidate a completed read/write.
+    }
   }
+
+  return result;
 }
 
 export async function loadStoredWallhavenKey(): Promise<string> {

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -234,11 +234,11 @@
 @layer components {
   .wh-desktop-shell {
     position: relative;
-    width: 100vw;
-    min-width: 1180px;
+    width: 100%;
+    min-width: 0;
     height: 100vh;
-    min-height: 760px;
-    overflow: auto;
+    min-height: 0;
+    overflow: hidden;
     background:
       radial-gradient(circle at 76% 14%, var(--shell-radial-glow), transparent 22%),
       linear-gradient(135deg, var(--app-gradient-start) 0%, var(--app-gradient-end) 100%);
@@ -246,11 +246,11 @@
 
   .wh-window-chrome {
     display: flex;
-    height: 58px;
+    height: 46px;
     align-items: center;
     justify-content: space-between;
     border-bottom: 1px solid var(--border);
-    padding: 0 22px;
+    padding: 0 clamp(12px, 2vw, 22px);
     background: color-mix(in srgb, var(--panel) 88%, transparent);
     backdrop-filter: blur(22px);
   }
@@ -281,22 +281,29 @@
 
   .wh-workspace {
     display: grid;
-    grid-template-columns: 198px minmax(0, 1fr);
-    column-gap: 30px;
-    min-height: calc(100vh - 58px);
-    padding: 12px 28px 22px 16px;
+    grid-template-columns: minmax(172px, 198px) minmax(0, 1fr);
+    column-gap: clamp(14px, 2vw, 30px);
+    height: calc(100vh - 46px);
+    min-height: 0;
+    padding: 12px clamp(12px, 2vw, 28px) 22px 16px;
+    overflow: hidden;
   }
 
   .app-shell-sidebar {
-    height: calc(100vh - 92px);
-    min-height: 720px;
+    height: calc(100vh - 80px);
+    min-height: 0;
+    overflow-y: auto;
     border-radius: 20px;
   }
 
   .app-shell-main {
     position: relative;
-    min-height: calc(100vh - 92px);
+    height: calc(100vh - 80px);
+    min-height: 0;
+    overflow-y: auto;
+    overflow-x: hidden;
     padding-top: 12px;
+    padding-right: 2px;
     animation: wh-page-in var(--motion-page);
   }
 
@@ -455,6 +462,63 @@
     to {
       opacity: 1;
       transform: translateY(0);
+    }
+  }
+
+  @media (max-width: 900px) {
+    .wh-workspace {
+      grid-template-columns: minmax(62px, 72px) minmax(0, 1fr);
+      column-gap: 12px;
+      padding: 10px 12px 14px;
+    }
+
+    .app-shell-sidebar {
+      padding-inline: 10px;
+    }
+
+    .app-shell-sidebar nav a,
+    .app-shell-sidebar > div:first-child {
+      justify-content: center;
+    }
+
+    .app-shell-sidebar nav a span,
+    .app-shell-sidebar > div:first-child p,
+    .app-shell-sidebar > div:nth-of-type(2),
+    .app-shell-sidebar > section {
+      display: none;
+    }
+  }
+
+  @media (max-width: 640px) {
+    .wh-workspace {
+      grid-template-columns: minmax(0, 1fr);
+      grid-template-rows: auto minmax(0, 1fr);
+      row-gap: 10px;
+      padding: 10px;
+    }
+
+    .app-shell-sidebar {
+      height: auto;
+      border-radius: 16px;
+      overflow-x: auto;
+      overflow-y: hidden;
+    }
+
+    .app-shell-sidebar nav {
+      display: flex;
+      gap: 8px;
+      white-space: nowrap;
+    }
+
+    .app-shell-sidebar nav a {
+      width: 42px;
+      flex: 0 0 42px;
+      padding-inline: 0;
+    }
+
+    .app-shell-main {
+      height: auto;
+      min-height: 0;
     }
   }
 }


### PR DESCRIPTION
## Summary
- Remove the duplicated in-app macOS chrome and make shell/search/settings layouts adapt to smaller windows.
- Keep Wallhaven thumbnails behind the Tauri media proxy instead of falling back to direct remote URLs.
- Let settings load with defaults when optional store-backed values are unavailable, and default Gallery to SFW.

## Tests
- npm run test:run
- npm run typecheck
- npm run build
