### PR TITLE
Make desktop controls perform bounded actions

### DIFF
--- a/src-tauri/src/commands/settings.rs
+++ b/src-tauri/src/commands/settings.rs
@@ -4,12 +4,16 @@ use tauri::{AppHandle, Manager, State};
 
 use crate::db::settings_repository::{SettingsRepository, SettingsStoreError};
 use crate::db::DatabaseState;
+use crate::models::search::{
+    WallhavenCategoryFilter, WallhavenPurityFilter, WallhavenSearchRequest, WallhavenSorting,
+};
 use crate::models::settings::{
     NetworkProxyScheme, NetworkProxySettings, NetworkProxySettingsError,
 };
 use crate::services::path_service::{
     resolve_effective_download_directory, ResolveDownloadPathError,
 };
+use crate::services::wallhaven_client::{WallhavenClient, WallhavenClientError};
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize)]
 #[serde(rename_all = "camelCase")]
@@ -47,11 +51,29 @@ pub struct SaveNetworkProxySettingsRequest {
     pub proxy: Option<NetworkProxySettingsDto>,
 }
 
+#[derive(Clone, Debug, PartialEq, Eq, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct DiagnoseWallhavenAccessRequest {
+    pub proxy: Option<NetworkProxySettingsDto>,
+    pub api_key: Option<String>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct WallhavenAccessDiagnosticDto {
+    pub uses_proxy: bool,
+    pub authenticated: bool,
+    pub total: u64,
+}
+
 #[derive(Clone, Debug, PartialEq, Eq, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub enum SettingsCommandErrorKind {
     InvalidRequest,
     ResolvePath,
+    UpstreamStatus,
+    Timeout,
+    Network,
     Internal,
 }
 
@@ -60,14 +82,51 @@ pub enum SettingsCommandErrorKind {
 pub struct SettingsCommandError {
     pub kind: SettingsCommandErrorKind,
     pub message: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub status_code: Option<u16>,
 }
 
 impl SettingsCommandError {
-    fn internal(message: impl Into<String>) -> Self {
+    fn new(kind: SettingsCommandErrorKind, message: impl Into<String>) -> Self {
         Self {
-            kind: SettingsCommandErrorKind::Internal,
+            kind,
             message: message.into(),
+            status_code: None,
         }
+    }
+
+    fn internal(message: impl Into<String>) -> Self {
+        Self::new(SettingsCommandErrorKind::Internal, message)
+    }
+
+    fn with_status(
+        kind: SettingsCommandErrorKind,
+        message: impl Into<String>,
+        status_code: u16,
+    ) -> Self {
+        Self {
+            kind,
+            message: message.into(),
+            status_code: Some(status_code),
+        }
+    }
+
+    fn from_reqwest_error(error: reqwest::Error) -> Self {
+        let message = error.to_string();
+
+        if let Some(status) = error.status() {
+            return Self::with_status(
+                SettingsCommandErrorKind::UpstreamStatus,
+                message,
+                status.as_u16(),
+            );
+        }
+
+        if error.is_timeout() {
+            return Self::new(SettingsCommandErrorKind::Timeout, message);
+        }
+
+        Self::new(SettingsCommandErrorKind::Network, message)
     }
 }
 
@@ -83,10 +142,12 @@ impl From<ResolveDownloadPathError> for SettingsCommandError {
             ResolveDownloadPathError::InvalidRootPath(message) => Self {
                 kind: SettingsCommandErrorKind::InvalidRequest,
                 message: message.to_string(),
+                status_code: None,
             },
             other => Self {
                 kind: SettingsCommandErrorKind::ResolvePath,
                 message: other.to_string(),
+                status_code: None,
             },
         }
     }
@@ -94,9 +155,21 @@ impl From<ResolveDownloadPathError> for SettingsCommandError {
 
 impl From<NetworkProxySettingsError> for SettingsCommandError {
     fn from(error: NetworkProxySettingsError) -> Self {
-        Self {
-            kind: SettingsCommandErrorKind::InvalidRequest,
-            message: error.to_string(),
+        Self::new(SettingsCommandErrorKind::InvalidRequest, error.to_string())
+    }
+}
+
+impl From<WallhavenClientError> for SettingsCommandError {
+    fn from(error: WallhavenClientError) -> Self {
+        match error {
+            WallhavenClientError::InvalidBaseUrl(message)
+            | WallhavenClientError::InvalidProxy(message) => {
+                Self::new(SettingsCommandErrorKind::InvalidRequest, message)
+            }
+            WallhavenClientError::InvalidRequest(error) => {
+                Self::new(SettingsCommandErrorKind::InvalidRequest, error.to_string())
+            }
+            WallhavenClientError::Request(error) => Self::from_reqwest_error(error),
         }
     }
 }
@@ -185,6 +258,7 @@ pub async fn get_download_directory_settings(
         .map_err(|error| SettingsCommandError {
             kind: SettingsCommandErrorKind::ResolvePath,
             message: error.to_string(),
+            status_code: None,
         })?;
 
     load_download_directory_settings_from_repository(
@@ -206,6 +280,7 @@ pub async fn save_download_directory_settings(
         .map_err(|error| SettingsCommandError {
             kind: SettingsCommandErrorKind::ResolvePath,
             message: error.to_string(),
+            status_code: None,
         })?;
     let custom_directory_path = normalize_custom_directory_input(request.custom_directory_path);
 
@@ -260,14 +335,55 @@ pub async fn save_network_proxy_settings(
         .map_err(Into::into)
 }
 
+#[tauri::command]
+pub async fn diagnose_wallhaven_access(
+    request: DiagnoseWallhavenAccessRequest,
+) -> Result<WallhavenAccessDiagnosticDto, SettingsCommandError> {
+    let proxy = request
+        .proxy
+        .map(NetworkProxySettings::try_from)
+        .transpose()?;
+    let api_key = request
+        .api_key
+        .as_deref()
+        .map(str::trim)
+        .filter(|key| !key.is_empty())
+        .map(str::to_string);
+    let client = WallhavenClient::with_proxy(proxy.as_ref())?;
+    let response = client
+        .search(&WallhavenSearchRequest {
+            categories: Some(WallhavenCategoryFilter::General),
+            purity: Some(WallhavenPurityFilter {
+                sfw: true,
+                sketchy: false,
+                nsfw: false,
+            }),
+            sorting: Some(WallhavenSorting::DateAdded),
+            top_range: None,
+            q: None,
+            page: Some(1),
+            at_least: None,
+            ratios: None,
+            api_key: api_key.clone(),
+        })
+        .await?;
+
+    Ok(WallhavenAccessDiagnosticDto {
+        uses_proxy: proxy.is_some(),
+        authenticated: api_key.is_some(),
+        total: response.meta.total,
+    })
+}
+
 #[cfg(test)]
 mod tests {
     use serde_json::json;
 
     use super::{
-        DownloadDirectorySettingsDto, NetworkProxySchemeDto, NetworkProxySettingsDto,
-        SaveDownloadDirectorySettingsRequest, SaveNetworkProxySettingsRequest,
-        SettingsCommandError, SettingsCommandErrorKind,
+        DiagnoseWallhavenAccessRequest, DownloadDirectorySettingsDto, NetworkProxySchemeDto,
+        NetworkProxySettingsDto, SaveDownloadDirectorySettingsRequest,
+        SaveNetworkProxySettingsRequest, SettingsCommandError, SettingsCommandErrorKind,
+        WallhavenAccessDiagnosticDto,
     };
     use crate::models::settings::NetworkProxySettingsError;
     use crate::services::path_service::{ResolveDownloadPathError, RootPathError};
@@ -343,6 +459,47 @@ mod tests {
                     address: "127.0.0.1:7897".into(),
                 })
             }
+        );
+    }
+
+    #[test]
+    fn diagnose_wallhaven_access_request_deserializes_in_camel_case() {
+        let request: DiagnoseWallhavenAccessRequest = serde_json::from_value(json!({
+            "proxy": {
+                "scheme": "socks5",
+                "address": "127.0.0.1:7897"
+            },
+            "apiKey": "test-key"
+        }))
+        .unwrap();
+
+        assert_eq!(
+            request,
+            DiagnoseWallhavenAccessRequest {
+                proxy: Some(NetworkProxySettingsDto {
+                    scheme: NetworkProxySchemeDto::Socks5,
+                    address: "127.0.0.1:7897".into(),
+                }),
+                api_key: Some("test-key".into())
+            }
+        );
+    }
+
+    #[test]
+    fn wallhaven_access_diagnostic_dto_serializes_in_camel_case() {
+        let dto = WallhavenAccessDiagnosticDto {
+            uses_proxy: true,
+            authenticated: true,
+            total: 42,
+        };
+
+        assert_eq!(
+            serde_json::to_value(dto).unwrap(),
+            json!({
+                "usesProxy": true,
+                "authenticated": true,
+                "total": 42
+            })
         );
     }
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -43,7 +43,8 @@ pub fn run() {
             commands::settings::get_download_directory_settings,
             commands::settings::save_download_directory_settings,
             commands::settings::get_network_proxy_settings,
-            commands::settings::save_network_proxy_settings
+            commands::settings::save_network_proxy_settings,
+            commands::settings::diagnose_wallhaven_access
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/src-tauri/src/models/search.rs
+++ b/src-tauri/src/models/search.rs
@@ -12,6 +12,8 @@ pub struct WallhavenSearchRequest {
     pub top_range: Option<WallhavenToplistRange>,
     pub q: Option<String>,
     pub page: Option<u32>,
+    pub at_least: Option<String>,
+    pub ratios: Option<String>,
     pub api_key: Option<String>,
 }
 
@@ -215,6 +217,14 @@ impl WallhavenSearchRequest {
             params.push(("page".into(), page.to_string()));
         }
 
+        if let Some(at_least) = &self.at_least {
+            params.push(("atleast".into(), at_least.clone()));
+        }
+
+        if let Some(ratios) = &self.ratios {
+            params.push(("ratios".into(), ratios.clone()));
+        }
+
         match (&self.sorting, &self.top_range) {
             (None, Some(_)) => return Err(WallhavenRequestError::TopRangeRequiresToplist),
             (Some(WallhavenSorting::Toplist), None) => {
@@ -264,6 +274,8 @@ mod tests {
             top_range: Some(WallhavenToplistRange::OneMonth),
             q: Some("landscape".into()),
             page: Some(2),
+            at_least: Some("1920x1080".into()),
+            ratios: Some("16x9,16x10".into()),
             api_key: Some("test-key".into()),
         };
 
@@ -274,6 +286,8 @@ mod tests {
                 ("purity".into(), "110".into()),
                 ("q".into(), "landscape".into()),
                 ("page".into(), "2".into()),
+                ("atleast".into(), "1920x1080".into()),
+                ("ratios".into(), "16x9,16x10".into()),
                 ("sorting".into(), "toplist".into()),
                 ("topRange".into(), "1M".into()),
                 ("order".into(), "desc".into()),

--- a/src-tauri/src/services/wallhaven_client.rs
+++ b/src-tauri/src/services/wallhaven_client.rs
@@ -190,6 +190,8 @@ mod tests {
                     top_range: Some(WallhavenToplistRange::OneMonth),
                     q: Some("landscape".into()),
                     page: Some(2),
+                    at_least: None,
+                    ratios: None,
                     api_key: Some("test-key".into()),
                 })
                 .await

--- a/src/application/settings/settings-service.test.ts
+++ b/src/application/settings/settings-service.test.ts
@@ -5,6 +5,7 @@ vi.mock("@/infrastructure/tauri/settings-repository", () => ({
     telemetryEnabled: false,
     cacheSizeBytes: 38_400_000,
   },
+  diagnoseWallhavenAccess: vi.fn(),
   loadStoredWallhavenKey: vi.fn(),
   saveStoredWallhavenKey: vi.fn(),
   loadDownloadDirectorySettings: vi.fn(),
@@ -16,6 +17,7 @@ vi.mock("@/infrastructure/tauri/settings-repository", () => ({
 }));
 
 import {
+  diagnoseWallhavenAccess as diagnoseWallhavenAccessInRepository,
   loadDownloadDirectorySettings,
   loadNetworkProxySettings,
   loadStoredWallhavenKey,
@@ -26,7 +28,11 @@ import {
   saveUserPreferences,
 } from "@/infrastructure/tauri/settings-repository";
 
-import { loadSettings, saveSettings } from "./settings-service";
+import {
+  diagnoseWallhavenAccess,
+  loadSettings,
+  saveSettings,
+} from "./settings-service";
 
 describe("settings-service", () => {
   const preferences = {
@@ -165,5 +171,51 @@ describe("settings-service", () => {
     });
 
     expect(saveNetworkProxySettings).toHaveBeenCalledWith(null);
+  });
+
+  it("diagnoses Wallhaven access with the current unsaved proxy and API key", async () => {
+    vi.mocked(diagnoseWallhavenAccessInRepository).mockResolvedValue({
+      usesProxy: true,
+      authenticated: true,
+      total: 42,
+    });
+
+    await expect(
+      diagnoseWallhavenAccess({
+        wallhavenKey: " test-key ",
+        networkProxyScheme: "socks5",
+        networkProxyAddress: " 127.0.0.1:7897 ",
+      }),
+    ).resolves.toEqual({
+      usesProxy: true,
+      authenticated: true,
+      total: 42,
+    });
+
+    expect(diagnoseWallhavenAccessInRepository).toHaveBeenCalledWith({
+      apiKey: "test-key",
+      proxy: {
+        scheme: "socks5",
+        address: "127.0.0.1:7897",
+      },
+    });
+  });
+
+  it("diagnoses direct Wallhaven access when proxy and API key are blank", async () => {
+    vi.mocked(diagnoseWallhavenAccessInRepository).mockResolvedValue({
+      usesProxy: false,
+      authenticated: false,
+      total: 12,
+    });
+
+    await diagnoseWallhavenAccess({
+      wallhavenKey: " ",
+      networkProxyScheme: "http",
+      networkProxyAddress: " ",
+    });
+
+    expect(diagnoseWallhavenAccessInRepository).toHaveBeenCalledWith({
+      proxy: null,
+    });
   });
 });

--- a/src/application/settings/settings-service.ts
+++ b/src/application/settings/settings-service.ts
@@ -1,5 +1,6 @@
 import {
   defaultSettingsPreferences,
+  diagnoseWallhavenAccess as diagnoseWallhavenAccessInRepository,
   loadDownloadDirectorySettings,
   loadNetworkProxySettings,
   loadStoredWallhavenKey,
@@ -15,7 +16,14 @@ import type {
   SaveSettingsInput,
   SettingsPreferences,
   SettingsSnapshot,
+  WallhavenAccessDiagnostic,
 } from "./settings.types";
+
+type DiagnoseWallhavenAccessInput = {
+  wallhavenKey?: string;
+  networkProxyScheme: SaveSettingsInput["networkProxyScheme"];
+  networkProxyAddress: string;
+};
 
 async function loadOptionalSetting<T>(loader: () => Promise<T>, fallback: T): Promise<T> {
   try {
@@ -63,6 +71,27 @@ export async function saveSettings(input: SaveSettingsInput): Promise<SettingsSn
     networkProxy: savedNetworkProxy,
     preferences,
   };
+}
+
+export async function diagnoseWallhavenAccess(
+  input: DiagnoseWallhavenAccessInput,
+): Promise<WallhavenAccessDiagnostic> {
+  const networkProxyAddress = input.networkProxyAddress.trim();
+  const wallhavenKey = input.wallhavenKey?.trim();
+  const request: Parameters<typeof diagnoseWallhavenAccessInRepository>[0] = {
+    proxy: networkProxyAddress
+      ? {
+          scheme: input.networkProxyScheme,
+          address: networkProxyAddress,
+        }
+      : null,
+  };
+
+  if (wallhavenKey) {
+    request.apiKey = wallhavenKey;
+  }
+
+  return diagnoseWallhavenAccessInRepository(request);
 }
 
 export async function loadSettingsPreferences(): Promise<SettingsPreferences> {

--- a/src/application/settings/settings.types.ts
+++ b/src/application/settings/settings.types.ts
@@ -12,6 +12,12 @@ export type NetworkProxySettings = {
   address: string;
 };
 
+export type WallhavenAccessDiagnostic = {
+  usesProxy: boolean;
+  authenticated: boolean;
+  total: number;
+};
+
 export type SettingsPreferences = {
   launchAtLogin: boolean;
   confirmBeforeDelete: boolean;
@@ -37,20 +43,26 @@ export type SaveSettingsInput = {
 export type SettingsCommandErrorKind =
   | "invalidRequest"
   | "resolvePath"
+  | "upstreamStatus"
+  | "timeout"
+  | "network"
   | "internal";
 
 export type SettingsCommandErrorPayload = {
   kind: SettingsCommandErrorKind;
   message: string;
+  statusCode?: number;
 };
 
 export class SettingsCommandError extends Error {
   kind: SettingsCommandErrorKind;
+  statusCode?: number;
 
-  constructor({ kind, message }: SettingsCommandErrorPayload) {
+  constructor({ kind, message, statusCode }: SettingsCommandErrorPayload) {
     super(message);
     this.name = "SettingsCommandError";
     this.kind = kind;
+    this.statusCode = statusCode;
   }
 }
 

--- a/src/components/mac-window-chrome.tsx
+++ b/src/components/mac-window-chrome.tsx
@@ -1,20 +1,91 @@
-import { HelpCircle, Keyboard } from "lucide-react";
+import { Download, HelpCircle, Images, Keyboard, Search, Settings } from "lucide-react";
+import type { LucideIcon } from "lucide-react";
+import { useNavigate } from "react-router-dom";
 
 import { ThemeToggle } from "@/components/theme-toggle";
+import { useUiShellStore } from "@/features/shell/ui-shell-store";
+
+type ChromeCommand = {
+  label: string;
+  to: string;
+  icon: LucideIcon;
+};
+
+const quickNavigationCommands: ChromeCommand[] = [
+  { label: "Search", to: "/search", icon: Search },
+  { label: "Downloads", to: "/downloads", icon: Download },
+  { label: "Gallery", to: "/gallery", icon: Images },
+  { label: "Settings", to: "/settings", icon: Settings },
+];
+
+const helpCommands: ChromeCommand[] = [
+  { label: "Open Settings", to: "/settings", icon: Settings },
+  { label: "Download Queue", to: "/downloads", icon: Download },
+];
 
 export function MacWindowChrome() {
+  const navigate = useNavigate();
+  const activeShellPanel = useUiShellStore((state) => state.activeShellPanel);
+  const setActiveShellPanel = useUiShellStore((state) => state.setActiveShellPanel);
+
+  const togglePanel = (panel: typeof activeShellPanel) => {
+    setActiveShellPanel(activeShellPanel === panel ? null : panel);
+  };
+
+  const runCommand = (to: string) => {
+    navigate(to);
+    setActiveShellPanel(null);
+  };
+
   return (
     <header aria-label="top bar" className="wh-window-chrome">
       <div aria-hidden="true" />
 
-      <div className="flex items-center gap-2">
-        <button aria-label="Keyboard shortcuts" className="wh-chrome-button" type="button">
+      <div className="relative flex items-center gap-2">
+        <button
+          aria-expanded={activeShellPanel === "quick-navigation"}
+          aria-label="Quick navigation"
+          className="wh-chrome-button"
+          onClick={() => togglePanel("quick-navigation")}
+          type="button"
+        >
           <Keyboard className="h-4 w-4" />
         </button>
-        <button aria-label="Help" className="wh-chrome-button" type="button">
+        <button
+          aria-expanded={activeShellPanel === "help"}
+          aria-label="Help"
+          className="wh-chrome-button"
+          onClick={() => togglePanel("help")}
+          type="button"
+        >
           <HelpCircle className="h-4 w-4" />
         </button>
         <ThemeToggle />
+
+        {activeShellPanel ? (
+          <div
+            aria-label={activeShellPanel === "quick-navigation" ? "Quick navigation commands" : "Help commands"}
+            className="absolute right-0 top-[calc(100%+10px)] z-40 w-[min(18rem,calc(100vw-1.5rem))] rounded-[18px] border border-border bg-[var(--panel)] p-2 shadow-[var(--panel-shadow)]"
+            role="menu"
+          >
+            {(activeShellPanel === "quick-navigation" ? quickNavigationCommands : helpCommands).map((command) => {
+              const Icon = command.icon;
+
+              return (
+                <button
+                  className="flex h-11 w-full items-center gap-3 rounded-[14px] px-3 text-left text-[13px] font-semibold text-muted-foreground transition hover:bg-[var(--surface-hover)] hover:text-foreground"
+                  key={command.label}
+                  onClick={() => runCommand(command.to)}
+                  role="menuitem"
+                  type="button"
+                >
+                  <Icon className="h-4 w-4" />
+                  <span>{command.label}</span>
+                </button>
+              );
+            })}
+          </div>
+        ) : null}
       </div>
     </header>
   );

--- a/src/components/sidebar.tsx
+++ b/src/components/sidebar.tsx
@@ -1,9 +1,12 @@
 import { Download, Heart, Images, Search, Settings } from "lucide-react";
 import type { LucideIcon } from "lucide-react";
-import { NavLink } from "react-router-dom";
+import { NavLink, useNavigate } from "react-router-dom";
 
 import { cn } from "@/lib/utils";
-import { useUiShellStore } from "@/features/shell/ui-shell-store";
+import {
+  type GalleryCollectionShortcut,
+  useUiShellStore,
+} from "@/features/shell/ui-shell-store";
 
 type NavigationItem = {
   to: string;
@@ -18,16 +21,18 @@ const navigationItems: NavigationItem[] = [
   { to: "/settings", label: "Settings", icon: Settings },
 ];
 
-const collectionItems = [
-  { label: "Favorites", count: 128, icon: Heart },
-  { label: "4K Ultra", count: 86, icon: Heart },
-  { label: "Nature", count: 42, icon: Heart },
-  { label: "Anime", count: 36, icon: Heart },
-  { label: "Space", count: 50, icon: Heart },
+const collectionItems: Array<{ label: GalleryCollectionShortcut; icon: LucideIcon }> = [
+  { label: "Favorites", icon: Heart },
+  { label: "4K Ultra", icon: Heart },
+  { label: "Nature", icon: Heart },
+  { label: "Anime", icon: Heart },
+  { label: "Space", icon: Heart },
 ];
 
 export function Sidebar() {
+  const navigate = useNavigate();
   const downloadSummary = useUiShellStore((state) => state.downloadSummary);
+  const requestGalleryCollection = useUiShellStore((state) => state.requestGalleryCollection);
 
   return (
     <aside
@@ -79,13 +84,20 @@ export function Sidebar() {
           {collectionItems.map((item) => {
             const Icon = item.icon;
             return (
-              <div key={item.label} className="flex h-[32px] items-center justify-between rounded-xl px-2 text-[13px] font-medium text-muted-foreground transition hover:bg-[var(--surface-hover)]/65 hover:text-foreground">
+              <button
+                className="flex h-[32px] w-full items-center justify-between rounded-xl px-2 text-left text-[13px] font-medium text-muted-foreground transition hover:bg-[var(--surface-hover)]/65 hover:text-foreground"
+                key={item.label}
+                onClick={() => {
+                  requestGalleryCollection(item.label);
+                  navigate("/gallery");
+                }}
+                type="button"
+              >
                 <div className="flex items-center gap-2">
                   <Icon className="h-4 w-4" />
                   <span>{item.label}</span>
                 </div>
-                <span className="text-xs font-medium text-muted-foreground/90">{item.count}</span>
-              </div>
+              </button>
             );
           })}
         </div>

--- a/src/components/top-bar.tsx
+++ b/src/components/top-bar.tsx
@@ -1,9 +1,11 @@
 import { Bell, Search as SearchIcon, Settings2 } from "lucide-react";
+import { useNavigate } from "react-router-dom";
 
 import { ThemeToggle } from "@/components/theme-toggle";
 import { useUiShellStore } from "@/features/shell/ui-shell-store";
 
 export function TopBar() {
+  const navigate = useNavigate();
   const globalQuery = useUiShellStore((state) => state.globalQuery);
   const setGlobalQuery = useUiShellStore((state) => state.setGlobalQuery);
   const downloadSummary = useUiShellStore((state) => state.downloadSummary);
@@ -48,6 +50,7 @@ export function TopBar() {
           <button
             aria-label="Open settings shortcuts"
             className="flex h-10 w-10 items-center justify-center rounded-full border border-border bg-background/50 text-muted-foreground transition hover:text-foreground"
+            onClick={() => navigate("/settings")}
             type="button"
           >
             <Settings2 className="h-4 w-4" />
@@ -55,6 +58,7 @@ export function TopBar() {
           <button
             aria-label="Open task notifications"
             className="relative flex h-10 w-10 items-center justify-center rounded-full border border-border bg-background/50 text-muted-foreground transition hover:text-foreground"
+            onClick={() => navigate("/downloads")}
             type="button"
           >
             <Bell className="h-4 w-4" />

--- a/src/domain/wallhaven/models.ts
+++ b/src/domain/wallhaven/models.ts
@@ -42,6 +42,8 @@ export interface WallhavenQueryFilterBase {
   purity?: WallhavenPurityFilter;
   q?: string;
   page?: number;
+  atLeast?: string;
+  ratios?: string;
 }
 
 export interface WallhavenToplistQueryFilters extends WallhavenQueryFilterBase {
@@ -63,6 +65,8 @@ export interface WallhavenQueryParamsBase {
   purity?: WallhavenPurityCode;
   q?: string;
   page?: string;
+  atleast?: string;
+  ratios?: string;
 }
 
 export interface WallhavenToplistQueryParams extends WallhavenQueryParamsBase {

--- a/src/domain/wallhaven/query-mappers.test.ts
+++ b/src/domain/wallhaven/query-mappers.test.ts
@@ -12,6 +12,8 @@ describe("buildWallhavenQueryParams", () => {
         topRange: "1M",
         q: "landscape",
         page: 2,
+        atLeast: "1920x1080",
+        ratios: "16x9,16x10",
       }),
     ).toEqual({
       categories: "110",
@@ -21,6 +23,8 @@ describe("buildWallhavenQueryParams", () => {
       order: "desc",
       q: "landscape",
       page: "2",
+      atleast: "1920x1080",
+      ratios: "16x9,16x10",
     });
   });
 

--- a/src/domain/wallhaven/query-mappers.ts
+++ b/src/domain/wallhaven/query-mappers.ts
@@ -31,6 +31,14 @@ function buildWallhavenQueryParamsBase(
     params.page = String(filters.page);
   }
 
+  if (filters.atLeast !== undefined) {
+    params.atleast = filters.atLeast;
+  }
+
+  if (filters.ratios !== undefined) {
+    params.ratios = filters.ratios;
+  }
+
   return params;
 }
 

--- a/src/features/downloads/DownloadsPage.test.tsx
+++ b/src/features/downloads/DownloadsPage.test.tsx
@@ -379,6 +379,31 @@ describe("DownloadsPage", () => {
     expect(await screen.findByText(/No downloads yet/i)).toBeInTheDocument()
   })
 
+  it("refreshes the download queue from the tasks header", async () => {
+    vi.mocked(listDownloads)
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([
+        {
+          id: "download-refresh",
+          wallpaperId: "refresh123",
+          fileName: "wallhaven-refresh123.jpg",
+          relativeFilePath: "wallpapers/wallhaven-refresh123.jpg",
+          status: "succeeded",
+        },
+      ])
+
+    render(<DownloadsPage />)
+
+    const user = userEvent.setup()
+    await screen.findByText(/No downloads yet/i)
+    await user.click(screen.getByRole("button", { name: /Refresh/i }))
+
+    expect(await screen.findByText("wallhaven-refresh123.jpg")).toBeInTheDocument()
+    await waitFor(() => {
+      expect(useUiShellStore.getState().toasts[0]?.title).toBe("Queue refreshed")
+    })
+  })
+
   it("opens the effective download directory from the command center", async () => {
     vi.mocked(listDownloads).mockResolvedValue([])
 

--- a/src/features/downloads/DownloadsPage.tsx
+++ b/src/features/downloads/DownloadsPage.tsx
@@ -1,4 +1,4 @@
-import { FolderOpen, Pause, Radio } from "lucide-react"
+import { FolderOpen, Radio, RefreshCcw } from "lucide-react"
 import { useEffect, useMemo, useState } from "react"
 
 import {
@@ -276,6 +276,24 @@ export function DownloadsPage() {
     }
   }
 
+  const refreshDownloads = async () => {
+    setIsLoading(true)
+    setLoadError(null)
+
+    try {
+      const loadedDownloads = await listDownloadsInService()
+      setDownloads((currentDownloads) =>
+        mergeLoadedDownloads(currentDownloads, loadedDownloads),
+      )
+      showToast("Queue refreshed", `${loadedDownloads.length} tasks loaded.`, "info")
+    } catch (error) {
+      setLoadError(getErrorMessage(error, "Failed to refresh downloads."))
+      showToast("Refresh failed", getErrorMessage(error, "Unable to reload download tasks."), "error")
+    } finally {
+      setIsLoading(false)
+    }
+  }
+
   const handlePrimaryAction = async (download: DownloadListItem) => {
     setPendingTaskAction(download.id, "primary")
 
@@ -438,9 +456,17 @@ export function DownloadsPage() {
                 进入页面后先拉取已有任务，再持续接收状态与进度事件。
               </p>
             </div>
-            <Button className="h-10 rounded-[14px]" disabled type="button" variant="outline">
-              <Pause className="h-4 w-4" />
-              Pause all
+            <Button
+              className="h-10 rounded-[14px]"
+              disabled={isLoading}
+              onClick={() => {
+                void refreshDownloads()
+              }}
+              type="button"
+              variant="outline"
+            >
+              <RefreshCcw className="h-4 w-4" />
+              Refresh
             </Button>
           </div>
 

--- a/src/features/gallery/GalleryPage.test.tsx
+++ b/src/features/gallery/GalleryPage.test.tsx
@@ -63,6 +63,25 @@ import { GalleryPage } from "./GalleryPage"
 
 const clipboardWriteText = vi.fn()
 
+function formatGalleryDate(date: Date): string {
+  const datePart = [
+    date.getFullYear(),
+    String(date.getMonth() + 1).padStart(2, "0"),
+    String(date.getDate()).padStart(2, "0"),
+  ].join("-")
+  const timePart = [
+    String(date.getHours()).padStart(2, "0"),
+    String(date.getMinutes()).padStart(2, "0"),
+    String(date.getSeconds()).padStart(2, "0"),
+  ].join(":")
+
+  return `${datePart} ${timePart}`
+}
+
+const now = new Date()
+const today = new Date(now.getFullYear(), now.getMonth(), now.getDate(), 8, 0, 0)
+const sixDaysAgo = new Date(now.getFullYear(), now.getMonth(), now.getDate() - 6, 12, 0, 0)
+
 const sampleResponse: GalleryListResponse = {
   items: [
     {
@@ -75,7 +94,7 @@ const sampleResponse: GalleryListResponse = {
       category: "general",
       tags: ["Nature"],
       isFavorite: false,
-      createdAt: "2026-05-24 12:00:00",
+      createdAt: formatGalleryDate(sixDaysAgo),
     },
     {
       wallpaperId: "pqrs12",
@@ -87,12 +106,24 @@ const sampleResponse: GalleryListResponse = {
       category: "anime",
       tags: ["Forest"],
       isFavorite: true,
-      createdAt: "2026-05-25 09:30:00",
+      createdAt: formatGalleryDate(sixDaysAgo),
+    },
+    {
+      wallpaperId: "space4k",
+      sourceUrl: "https://wallhaven.cc/w/space4k",
+      fileName: "space-4k-ultra.jpg",
+      relativeFilePath: "wallpapers/space-4k-ultra.jpg",
+      absolutePath: "/Users/test/Library/Application Support/cc.zhengyh.wallhaven.desktop/wallpapers/space-4k-ultra.jpg",
+      purity: "sfw",
+      category: "general",
+      tags: ["Space", "UHD"],
+      isFavorite: false,
+      createdAt: formatGalleryDate(today),
     },
   ],
   page: 1,
   pageSize: 60,
-  total: 2,
+  total: 3,
 }
 
 describe("GalleryPage", () => {
@@ -112,7 +143,11 @@ describe("GalleryPage", () => {
       cacheSizeBytes: 38_400_000,
     })
     vi.mocked(revealPath).mockResolvedValue(undefined)
-    useUiShellStore.setState({ galleryView: "grid", toasts: [] })
+    useUiShellStore.setState({
+      galleryCollectionRequest: null,
+      galleryView: "grid",
+      toasts: [],
+    })
   })
 
   it("loads gallery items on entry and renders an empty state when the archive is empty", async () => {
@@ -164,6 +199,7 @@ describe("GalleryPage", () => {
 
     expect(await screen.findByRole("button", { name: "SFW", pressed: true })).toBeInTheDocument()
     expect(screen.getAllByText("wallhaven-kxpkmm.jpg").length).toBeGreaterThan(0)
+    expect(screen.getAllByText("space-4k-ultra.jpg").length).toBeGreaterThan(0)
     expect(screen.queryByText("forest-scene.png")).not.toBeInTheDocument()
   })
 
@@ -181,6 +217,33 @@ describe("GalleryPage", () => {
 
     expect(screen.getAllByText("forest-scene.png").length).toBeGreaterThan(0)
     expect(screen.queryByText("wallhaven-kxpkmm.jpg")).not.toBeInTheDocument()
+  })
+
+  it("applies sidebar collection requests to the gallery archive", async () => {
+    vi.mocked(loadInitialGalleryItems).mockResolvedValue(sampleResponse)
+
+    render(<GalleryPage />)
+
+    expect((await screen.findAllByText("wallhaven-kxpkmm.jpg")).length).toBeGreaterThan(0)
+
+    useUiShellStore.getState().requestGalleryCollection("Space")
+
+    expect(await screen.findByText("space-4k-ultra.jpg")).toBeInTheDocument()
+    expect(screen.queryByText("wallhaven-kxpkmm.jpg")).not.toBeInTheDocument()
+    expect(screen.queryByText("forest-scene.png")).not.toBeInTheDocument()
+  })
+
+  it("opens timeline groups as local gallery filters", async () => {
+    vi.mocked(loadInitialGalleryItems).mockResolvedValue(sampleResponse)
+
+    render(<GalleryPage />)
+
+    const user = userEvent.setup()
+    await user.click(await screen.findByRole("button", { name: /Open group Today/i }))
+
+    expect(screen.getAllByText("space-4k-ultra.jpg").length).toBeGreaterThan(0)
+    expect(screen.queryByText("wallhaven-kxpkmm.jpg")).not.toBeInTheDocument()
+    expect(screen.queryByText("forest-scene.png")).not.toBeInTheDocument()
   })
 
   it("persists the selected gallery view in the shell store", async () => {

--- a/src/features/gallery/GalleryPage.tsx
+++ b/src/features/gallery/GalleryPage.tsx
@@ -16,7 +16,10 @@ import { ErrorState } from "@/components/error-state"
 import { LoadingSkeleton } from "@/components/loading-skeleton"
 import { PageHeading } from "@/components/page-heading"
 import { Button } from "@/components/ui/button"
-import { useUiShellStore } from "@/features/shell/ui-shell-store"
+import {
+  type GalleryCollectionShortcut,
+  useUiShellStore,
+} from "@/features/shell/ui-shell-store"
 import { revealPath } from "@/infrastructure/tauri/native-shell"
 
 import { GalleryGrid, type GalleryGridItem } from "./components/GalleryGrid"
@@ -44,6 +47,12 @@ function matchesLocalQuery(item: GalleryGridItem, query: string): boolean {
 }
 
 const filterChips = ["All", "Favorites", "SFW", "Sketchy", "NSFW", "Anime"] as const
+type FilterChip = (typeof filterChips)[number]
+
+const collectionChipByShortcut: Partial<Record<GalleryCollectionShortcut, FilterChip>> = {
+  Favorites: "Favorites",
+  Anime: "Anime",
+}
 
 function formatDisplayPath(path: string | null): string {
   if (!path) {
@@ -109,17 +118,101 @@ function parseTagDraft(value: string): string[] {
   return Array.from(new Set(tags))
 }
 
+function matchesTermBucket(item: GalleryGridItem, terms: string[]): boolean {
+  const searchableText = [
+    item.fileName,
+    item.relativeFilePath,
+    item.sourceUrl,
+    item.category ?? "",
+    item.purity ?? "",
+    ...item.tags,
+  ]
+    .join(" ")
+    .toLowerCase()
+
+  return terms.some((term) => searchableText.includes(term))
+}
+
+function matchesCollectionShortcut(item: GalleryGridItem, shortcut: GalleryCollectionShortcut | null): boolean {
+  if (!shortcut) {
+    return true
+  }
+
+  switch (shortcut) {
+    case "Favorites":
+      return item.isFavorite
+    case "Anime":
+      return item.category === "anime" || matchesTermBucket(item, ["anime"])
+    case "Nature":
+      return matchesTermBucket(item, ["nature", "forest", "mountain", "landscape", "river", "sky"])
+    case "Space":
+      return matchesTermBucket(item, ["space", "star", "galaxy", "nebula", "planet"])
+    case "4K Ultra":
+      return matchesTermBucket(item, ["4k", "uhd", "3840", "2160"])
+  }
+}
+
+type ImportGroupLabel = "Today" | "Yesterday" | "Last 7 days" | "This month"
+
+const importGroupLabels: ImportGroupLabel[] = ["Today", "Yesterday", "Last 7 days", "This month"]
+
+function parseCreatedAt(createdAt: string): Date | null {
+  const createdDate = new Date(createdAt.replace(" ", "T"))
+
+  if (Number.isNaN(createdDate.getTime())) {
+    return null
+  }
+
+  return createdDate
+}
+
+function isInImportGroup(createdAt: string, group: string | null, now = new Date()): boolean {
+  if (!group) {
+    return true
+  }
+
+  const createdDate = parseCreatedAt(createdAt)
+  if (!createdDate) {
+    return group === "This month"
+  }
+
+  const startOfToday = new Date(now.getFullYear(), now.getMonth(), now.getDate())
+  const startOfTomorrow = new Date(startOfToday)
+  startOfTomorrow.setDate(startOfTomorrow.getDate() + 1)
+  const startOfYesterday = new Date(startOfToday)
+  startOfYesterday.setDate(startOfYesterday.getDate() - 1)
+  const startOfSevenDays = new Date(startOfToday)
+  startOfSevenDays.setDate(startOfSevenDays.getDate() - 6)
+  const startOfMonth = new Date(now.getFullYear(), now.getMonth(), 1)
+
+  switch (group) {
+    case "Today":
+      return createdDate >= startOfToday && createdDate < startOfTomorrow
+    case "Yesterday":
+      return createdDate >= startOfYesterday && createdDate < startOfToday
+    case "Last 7 days":
+      return createdDate >= startOfSevenDays && createdDate < startOfTomorrow
+    case "This month":
+      return createdDate >= startOfMonth && createdDate < startOfTomorrow
+    default:
+      return true
+  }
+}
+
 export function GalleryPage() {
   const [gallery, setGallery] = useState<GalleryListResponse | null>(null)
   const [isLoading, setIsLoading] = useState(true)
   const [loadError, setLoadError] = useState<string | null>(null)
   const [localQuery, setLocalQuery] = useState("")
   const [activeChip, setActiveChip] = useState<(typeof filterChips)[number]>("SFW")
+  const [activeCollectionShortcut, setActiveCollectionShortcut] = useState<GalleryCollectionShortcut | null>(null)
+  const [activeImportGroup, setActiveImportGroup] = useState<ImportGroupLabel | null>(null)
   const [selectedWallpaperId, setSelectedWallpaperId] = useState<string | null>(null)
   const [tagDraft, setTagDraft] = useState("")
   const [pendingAction, setPendingAction] = useState<string | null>(null)
   const [confirmBeforeDelete, setConfirmBeforeDelete] = useState(true)
   const galleryView = useUiShellStore((state) => state.galleryView)
+  const galleryCollectionRequest = useUiShellStore((state) => state.galleryCollectionRequest)
   const setGalleryView = useUiShellStore((state) => state.setGalleryView)
   const enqueueToast = useUiShellStore((state) => state.enqueueToast)
   const setConfirm = useUiShellStore((state) => state.setConfirm)
@@ -167,6 +260,19 @@ export function GalleryPage() {
     }
   }, [])
 
+  useEffect(() => {
+    if (!galleryCollectionRequest) {
+      return
+    }
+
+    const chip = collectionChipByShortcut[galleryCollectionRequest.label]
+    setActiveChip(chip ?? "All")
+    setActiveCollectionShortcut(chip ? null : galleryCollectionRequest.label)
+    setActiveImportGroup(null)
+    setLocalQuery("")
+    setSelectedWallpaperId(null)
+  }, [galleryCollectionRequest])
+
   const galleryItems = useMemo(
     () =>
       gallery?.items.map((item) => ({
@@ -183,10 +289,6 @@ export function GalleryPage() {
           return false
         }
 
-        if (activeChip === "All") {
-          return true
-        }
-
         if (activeChip === "Favorites") {
           return item.isFavorite
         }
@@ -199,9 +301,17 @@ export function GalleryPage() {
           return item.category === "anime" || item.fileName.toLowerCase().includes("anime")
         }
 
+        if (!matchesCollectionShortcut(item, activeCollectionShortcut)) {
+          return false
+        }
+
+        if (!isInImportGroup(item.createdAt, activeImportGroup)) {
+          return false
+        }
+
         return true
       }),
-    [activeChip, galleryItems, normalizedLocalQuery],
+    [activeChip, activeCollectionShortcut, activeImportGroup, galleryItems, normalizedLocalQuery],
   )
 
   const selectedItem = useMemo(
@@ -217,15 +327,32 @@ export function GalleryPage() {
         gallery,
         filteredGalleryItems.length,
         galleryItems.length,
-        normalizedLocalQuery.length > 0 || activeChip !== "All",
+        normalizedLocalQuery.length > 0 ||
+          activeChip !== "All" ||
+          activeCollectionShortcut !== null ||
+          activeImportGroup !== null,
       ),
-    [activeChip, filteredGalleryItems.length, gallery, galleryItems.length, normalizedLocalQuery.length],
+    [
+      activeChip,
+      activeCollectionShortcut,
+      activeImportGroup,
+      filteredGalleryItems.length,
+      gallery,
+      galleryItems.length,
+      normalizedLocalQuery.length,
+    ],
   )
   const galleryPathLabel = useMemo(
     () => formatDisplayPath(selectedItem?.absolutePath ?? galleryItems[0]?.absolutePath ?? null),
     [galleryItems, selectedItem],
   )
   const selectedTags = useMemo(() => getDetailTags(selectedItem), [selectedItem])
+  const timelineGroups = useMemo(() => {
+    return importGroupLabels.map((label) => ({
+      label,
+      count: galleryItems.filter((item) => isInImportGroup(item.createdAt, label)).length,
+    }))
+  }, [galleryItems])
 
   useEffect(() => {
     setTagDraft(selectedItem?.tags.join(", ") ?? "")
@@ -399,6 +526,8 @@ export function GalleryPage() {
               disabled={isLoading && !gallery}
               onChange={(event) => {
                 setLocalQuery(event.currentTarget.value)
+                setActiveCollectionShortcut(null)
+                setActiveImportGroup(null)
               }}
               placeholder="Search local library"
               type="search"
@@ -415,7 +544,11 @@ export function GalleryPage() {
                   : "h-[42px] rounded-full border border-border bg-[var(--surface-deep)] px-4 text-[13px] font-semibold text-muted-foreground transition hover:border-border-strong hover:text-foreground"
               }
               key={chip}
-              onClick={() => setActiveChip(chip)}
+              onClick={() => {
+                setActiveChip(chip)
+                setActiveCollectionShortcut(null)
+                setActiveImportGroup(null)
+              }}
               type="button"
             >
               {chip}
@@ -497,22 +630,31 @@ export function GalleryPage() {
                 <h3 className="text-[20px] font-semibold leading-7 text-foreground">Timeline</h3>
                 <div className="mt-6 grid grid-cols-[1fr_296px] gap-6">
                   <div className="space-y-5">
-                    {[
-                      ["Today", "24 imported"],
-                      ["Yesterday", "16 imported"],
-                      ["Last 7 days", `${Math.max(galleryItems.length, 1)} imported`],
-                      ["This month", `${gallery?.total ?? galleryItems.length} archived`],
-                    ].map(([label, count], index) => (
+                    {timelineGroups.map(({ label, count }, index) => (
                       <div className="grid grid-cols-[18px_1fr_120px] items-center gap-4" key={label}>
-                        <span className={index === 0 ? "h-3 w-3 rounded-full bg-primary" : "h-3 w-3 rounded-full bg-[var(--timeline-dot-muted)]"} />
+                        <span className={activeImportGroup === label || (!activeImportGroup && index === 0) ? "h-3 w-3 rounded-full bg-primary" : "h-3 w-3 rounded-full bg-[var(--timeline-dot-muted)]"} />
                         <span className="text-[14px] font-semibold text-foreground">{label}</span>
-                        <span className="text-[13px] font-medium text-muted-foreground">{count}</span>
+                        <span className="text-[13px] font-medium text-muted-foreground">{count} imported</span>
                       </div>
                     ))}
                   </div>
                   <div className="space-y-3">
-                    {["Today", "Yesterday", "Last 7 days", "This month"].map((label) => (
-                      <Button className="h-10 w-full justify-start rounded-[14px]" key={label} type="button" variant="outline">
+                    {timelineGroups.map(({ label, count }) => (
+                      <Button
+                        aria-label={`Open group ${label}`}
+                        className="h-10 w-full justify-start rounded-[14px]"
+                        disabled={count === 0}
+                        key={label}
+                        onClick={() => {
+                          setActiveChip("All")
+                          setActiveCollectionShortcut(null)
+                          setActiveImportGroup(label)
+                          setLocalQuery("")
+                          setSelectedWallpaperId(null)
+                        }}
+                        type="button"
+                        variant="outline"
+                      >
                         Open group
                         <span className="sr-only">{label}</span>
                       </Button>

--- a/src/features/search/SearchPage.test.tsx
+++ b/src/features/search/SearchPage.test.tsx
@@ -180,6 +180,7 @@ describe("SearchPage", () => {
         purity: { sfw: true, sketchy: true, nsfw: false },
         sorting: "toplist",
         topRange: "1M",
+        ratios: "16x9",
         q: "aurora",
         page: 2,
       })
@@ -309,6 +310,7 @@ describe("SearchPage", () => {
         categories: "all",
         purity: { sfw: true, sketchy: false, nsfw: false },
         sorting: "date_added",
+        ratios: "16x9",
         q: "",
         page: 2,
       })
@@ -735,6 +737,29 @@ describe("SearchPage", () => {
     expect(screen.getByLabelText(/批量页数/i)).toHaveValue(3)
     expect(screen.getByText(/1966x3000/i)).toBeInTheDocument()
     expect(searchWallpapers).toHaveBeenCalledTimes(1)
+  })
+
+  it("submits resolution and aspect ratio filters through the structured search contract", async () => {
+    vi.mocked(searchWallpapers).mockResolvedValue(sampleResponse)
+
+    render(<SearchPage />)
+
+    const user = userEvent.setup()
+    await user.selectOptions(screen.getByLabelText(/分辨率/i), "3840x2160")
+    await user.selectOptions(screen.getByLabelText(/宽高比/i), "21x9")
+    await user.click(screen.getByRole("button", { name: /搜索/i }))
+
+    await waitFor(() => {
+      expect(searchWallpapers).toHaveBeenCalledWith({
+        categories: "all",
+        purity: { sfw: true, sketchy: false, nsfw: false },
+        sorting: "date_added",
+        atLeast: "3840x2160",
+        ratios: "21x9",
+        q: "",
+        page: 1,
+      })
+    })
   })
 
   it("keeps draft form values but clears stale results after remount when the draft diverges from the last submitted search", async () => {

--- a/src/features/search/SearchPage.tsx
+++ b/src/features/search/SearchPage.tsx
@@ -35,6 +35,8 @@ const searchSchema = z.object({
   purityPreset: z.enum(["sfw", "sketchy", "nsfw", "ws", "wn", "sn", "all"]),
   sorting: z.enum(["date_added", "toplist"]),
   topRange: z.enum(VALID_TOPLIST_RANGES),
+  resolution: z.enum(["all", "1920x1080", "2560x1440", "3840x2160"]),
+  aspectRatio: z.enum(["all", "16x9", "16x10", "21x9", "4x3", "portrait"]),
   q: z.string().max(200, "Query is unexpectedly long."),
   page: z.number().int().min(1, "Page must be at least 1."),
   pagesToDownload: z.number().int().min(1, "Pages to download must be at least 1."),
@@ -80,6 +82,8 @@ function buildSearchFilters(values: SearchPageFormValues): WallhavenQueryFilters
     purity: buildPurityFilter(values.purityPreset),
     q: values.q.trim(),
     page: values.page,
+    ...(values.resolution === "all" ? {} : { atLeast: values.resolution }),
+    ...(values.aspectRatio === "all" ? {} : { ratios: values.aspectRatio }),
   };
 
   if (values.sorting === "toplist") {
@@ -116,6 +120,8 @@ function areFormValuesEqual(
     left.purityPreset === right.purityPreset &&
     left.sorting === right.sorting &&
     left.topRange === right.topRange &&
+    left.resolution === right.resolution &&
+    left.aspectRatio === right.aspectRatio &&
     left.q === right.q &&
     left.page === right.page &&
     left.pagesToDownload === right.pagesToDownload
@@ -249,6 +255,8 @@ export function SearchPage() {
       purityPreset: "sfw",
       sorting: "date_added",
       topRange: "1M",
+      resolution: "all",
+      aspectRatio: "16x9",
       q: "",
       page: 1,
       pagesToDownload: 1,
@@ -325,6 +333,17 @@ export function SearchPage() {
     return `${result.meta.total.toLocaleString()} results · Page ${result.meta.currentPage} of ${result.meta.lastPage}`;
   }, [result]);
   const inspectorWallpaper = selectedWallpapers[0] ?? null;
+
+  const saveSelectedToCollection = () => {
+    if (selectedWallpapers.length === 0) {
+      return;
+    }
+
+    setDownloadFeedback({
+      tone: "success",
+      message: `${formatWallpaperCount(selectedWallpapers.length)} 已保留为当前选择，可继续批量下载或清除选择。`,
+    });
+  };
 
   const onSubmit = handleSubmit(async (values) => {
     setSearchError(null);
@@ -647,14 +666,26 @@ export function SearchPage() {
                     <option value="toplist">Toplist</option>
                   </select>
                 </label>
-                <div className="wh-control flex h-[54px] flex-col justify-center px-4" aria-label="Resolution">
+                <label className="wh-control flex h-[54px] flex-col justify-center px-4" htmlFor="search-resolution">
                   <span className="text-[9px] font-semibold uppercase leading-4 text-muted-foreground">Resolution</span>
-                  <span className="text-[13px] font-semibold">All</span>
-                </div>
-                <div className="wh-control flex h-[54px] flex-col justify-center px-4" aria-label="Aspect Ratio">
+                  <select aria-label="分辨率" className="bg-transparent text-[13px] font-semibold outline-none" id="search-resolution" {...register("resolution")}>
+                    <option value="all">All</option>
+                    <option value="1920x1080">1080p+</option>
+                    <option value="2560x1440">2K+</option>
+                    <option value="3840x2160">4K+</option>
+                  </select>
+                </label>
+                <label className="wh-control flex h-[54px] flex-col justify-center px-4" htmlFor="search-aspect-ratio">
                   <span className="text-[9px] font-semibold uppercase leading-4 text-muted-foreground">Aspect Ratio</span>
-                  <span className="text-[13px] font-semibold">16:9</span>
-                </div>
+                  <select aria-label="宽高比" className="bg-transparent text-[13px] font-semibold outline-none" id="search-aspect-ratio" {...register("aspectRatio")}>
+                    <option value="all">All</option>
+                    <option value="16x9">16:9</option>
+                    <option value="16x10">16:10</option>
+                    <option value="21x9">21:9</option>
+                    <option value="4x3">4:3</option>
+                    <option value="portrait">Portrait</option>
+                  </select>
+                </label>
                 <label className="wh-control flex h-[54px] flex-col justify-center px-4" htmlFor="search-top-range">
                   <span className="text-[9px] font-semibold uppercase leading-4 text-muted-foreground">More Filters</span>
                   <span className="flex items-center justify-between gap-3">
@@ -708,8 +739,14 @@ export function SearchPage() {
                     24 per page
                     <SlidersHorizontal className="h-4 w-4 text-muted-foreground" />
                   </div>
-                  <button aria-label="Grid view" className="wh-icon-button h-[42px] w-[42px]" type="button">
-                    <SlidersHorizontal className="h-4 w-4 text-primary" />
+                  <button
+                    aria-label="Clear selection"
+                    className="wh-icon-button h-[42px] w-[42px]"
+                    disabled={selectedSearchIds.length === 0 || isSelectedDownloading}
+                    onClick={clearSelectedSearchIds}
+                    type="button"
+                  >
+                    <X className="h-4 w-4 text-primary" />
                   </button>
                 </div>
               ) : null}
@@ -799,9 +836,14 @@ export function SearchPage() {
                 {isSelectedDownloading ? <Loader2 className="h-4 w-4 animate-spin" /> : <Download className="h-4 w-4" />}
                 Start download
               </Button>
-              <Button className="h-12 w-full rounded-[14px]" type="button" variant="outline">
+              <Button
+                className="h-12 w-full rounded-[14px]"
+                onClick={saveSelectedToCollection}
+                type="button"
+                variant="outline"
+              >
                 <Save className="h-4 w-4" />
-                Save to collection
+                Keep selection
               </Button>
               <Button
                 aria-label="清除选择"

--- a/src/features/search/search-page-session.ts
+++ b/src/features/search/search-page-session.ts
@@ -10,6 +10,8 @@ export type SearchPageFormValues = {
   purityPreset: "sfw" | "sketchy" | "nsfw" | "ws" | "wn" | "sn" | "all";
   sorting: "date_added" | "toplist";
   topRange: WallhavenToplistRange;
+  resolution: "all" | "1920x1080" | "2560x1440" | "3840x2160";
+  aspectRatio: "all" | "16x9" | "16x10" | "21x9" | "4x3" | "portrait";
   q: string;
   page: number;
   pagesToDownload: number;

--- a/src/features/settings/SettingsPage.test.tsx
+++ b/src/features/settings/SettingsPage.test.tsx
@@ -2,7 +2,11 @@ import { render, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 
 import { ConfirmDialog } from "@/components/confirm-dialog";
-import { loadSettings, saveSettings } from "@/application/settings/settings-service";
+import {
+  diagnoseWallhavenAccess,
+  loadSettings,
+  saveSettings,
+} from "@/application/settings/settings-service";
 import type { SettingsSnapshot } from "@/application/settings/settings.types";
 import { useUiShellStore } from "@/features/shell/ui-shell-store";
 
@@ -14,6 +18,7 @@ const { chooseDirectory, revealPath } = vi.hoisted(() => ({
 }));
 
 vi.mock("@/application/settings/settings-service", () => ({
+  diagnoseWallhavenAccess: vi.fn(),
   loadSettings: vi.fn(),
   saveSettings: vi.fn(),
 }));
@@ -66,6 +71,11 @@ describe("SettingsPage", () => {
     useUiShellStore.setState({ toasts: [], confirm: null });
     vi.mocked(loadSettings).mockResolvedValue(defaultSnapshot);
     vi.mocked(saveSettings).mockResolvedValue(defaultSnapshot);
+    vi.mocked(diagnoseWallhavenAccess).mockResolvedValue({
+      usesProxy: true,
+      authenticated: true,
+      total: 128,
+    });
     vi.mocked(chooseDirectory).mockResolvedValue(null);
     vi.mocked(revealPath).mockResolvedValue(undefined);
   });
@@ -86,6 +96,8 @@ describe("SettingsPage", () => {
     expect(await screen.findByLabelText(/^API Key$/i, { selector: "input" })).toHaveValue("existing-key");
     expect(screen.getByLabelText(/Download path/i)).toHaveValue("/Users/test/Pictures/Wallhaven");
     expect(screen.getByLabelText(/Proxy address/i)).toHaveValue("127.0.0.1:7897");
+    expect(screen.getByRole("button", { name: /^HTTP$/i })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /^HTTPS$/i })).toBeInTheDocument();
     expect(screen.getByRole("button", { name: /SOCKS5/i })).toHaveAttribute("aria-pressed", "true");
     expect(screen.getByRole("switch", { name: /Ask before deleting/i })).toHaveAttribute("aria-checked", "true");
   });
@@ -193,7 +205,7 @@ describe("SettingsPage", () => {
     expect(revealPath).toHaveBeenCalledWith("/Users/test/Pictures/Wallhaven");
   });
 
-  it("validates masked API key input and reports success without exposing logs", async () => {
+  it("validates masked API key input through the Wallhaven diagnostic service", async () => {
     render(
       <>
         <SettingsPage />
@@ -205,8 +217,35 @@ describe("SettingsPage", () => {
     await screen.findByLabelText(/^API Key$/i, { selector: "input" });
     await user.click(screen.getByRole("button", { name: /Validate key/i }));
 
-    expect((await screen.findAllByText(/API key validated/i)).length).toBeGreaterThan(0);
-    expect(await screen.findByRole("status")).toHaveTextContent(/API key validated/i);
+    await waitFor(() => {
+      expect(diagnoseWallhavenAccess).toHaveBeenCalledWith({
+        wallhavenKey: "existing-key",
+        networkProxyScheme: "socks5",
+        networkProxyAddress: "127.0.0.1:7897",
+      });
+    });
+    expect((await screen.findAllByText(/Wallhaven accepted the request/i)).length).toBeGreaterThan(0);
+  });
+
+  it("tests proxy connectivity through the Wallhaven diagnostic service", async () => {
+    render(
+      <>
+        <SettingsPage />
+        <ToastProbe />
+      </>,
+    );
+
+    const user = userEvent.setup();
+    await screen.findByLabelText(/^API Key$/i, { selector: "input" });
+    await user.click(screen.getByRole("button", { name: /^Test$/i }));
+
+    await waitFor(() => {
+      expect(diagnoseWallhavenAccess).toHaveBeenCalledWith({
+        networkProxyScheme: "socks5",
+        networkProxyAddress: "127.0.0.1:7897",
+      });
+    });
+    expect((await screen.findAllByText(/SOCKS5 proxy reached Wallhaven/i)).length).toBeGreaterThan(0);
   });
 
   it("blocks saving invalid directory and proxy values near the controls", async () => {
@@ -223,7 +262,7 @@ describe("SettingsPage", () => {
     expect(screen.getByRole("button", { name: /Save settings/i })).toBeDisabled();
   });
 
-  it("clears cache through the confirmation dialog without deleting originals", async () => {
+  it("resets the cache estimate through the confirmation dialog without deleting originals", async () => {
     render(
       <>
         <SettingsPage />
@@ -233,13 +272,13 @@ describe("SettingsPage", () => {
 
     const user = userEvent.setup();
     await screen.findByLabelText(/^API Key$/i, { selector: "input" });
-    await user.click(screen.getByRole("button", { name: /Clear cache/i }));
+    await user.click(screen.getByRole("button", { name: /Reset cache meter/i }));
 
-    expect(screen.getByRole("dialog", { name: /Clear cache/i })).toBeInTheDocument();
+    expect(screen.getByRole("dialog", { name: /Reset cache estimate/i })).toBeInTheDocument();
     expect(screen.getByText(/Downloaded wallpaper originals stay in place/i)).toBeInTheDocument();
-    await user.click(within(screen.getByRole("dialog", { name: /Clear cache/i })).getByRole("button", { name: /^Clear cache$/i }));
+    await user.click(within(screen.getByRole("dialog", { name: /Reset cache estimate/i })).getByRole("button", { name: /^Reset estimate$/i }));
 
-    expect(await screen.findByText(/0 MB · cleaning never removes downloaded wallpaper originals/i)).toBeInTheDocument();
+    expect(await screen.findByText(/0 MB · meter reset never removes downloaded wallpaper originals/i)).toBeInTheDocument();
   });
 
   it("shows the shared storage error state and disables saving when settings fail to load", async () => {

--- a/src/features/settings/SettingsPage.tsx
+++ b/src/features/settings/SettingsPage.tsx
@@ -9,13 +9,16 @@ import {
   RefreshCcw,
   ShieldCheck,
   TestTube2,
-  Trash2,
 } from "lucide-react";
 import { useEffect, useMemo, useState } from "react";
 import { useForm } from "react-hook-form";
 import { z } from "zod";
 
-import { loadSettings, saveSettings } from "@/application/settings/settings-service";
+import {
+  diagnoseWallhavenAccess,
+  loadSettings,
+  saveSettings,
+} from "@/application/settings/settings-service";
 import type {
   DownloadDirectorySettings,
   NetworkProxyScheme,
@@ -57,6 +60,7 @@ type EffectiveDestinationSummary = {
 
 const proxyOptions: Array<{ value: NetworkProxyScheme; label: string }> = [
   { value: "http", label: "HTTP" },
+  { value: "https", label: "HTTPS" },
   { value: "socks5", label: "SOCKS5" },
 ];
 
@@ -157,7 +161,7 @@ export function SettingsPage() {
   const [apiKeyStatus, setApiKeyStatus] = useState<SaveFeedback | null>(null);
   const [proxyStatus, setProxyStatus] = useState<SaveFeedback | null>(null);
   const [isTestingProxy, setIsTestingProxy] = useState(false);
-  const [isClearingCache, setIsClearingCache] = useState(false);
+  const [isResettingCacheEstimate, setIsResettingCacheEstimate] = useState(false);
   const [isChoosingDirectory, setIsChoosingDirectory] = useState(false);
   const [isRevealingDirectory, setIsRevealingDirectory] = useState(false);
   const enqueueToast = useUiShellStore((state) => state.enqueueToast);
@@ -306,67 +310,128 @@ export function SettingsPage() {
   };
 
   const validateApiKey = async () => {
+    const trimmedKey = values.wallhavenKey.trim();
+
+    if (proxyAddressError) {
+      const status = { tone: "error" as const, message: "Fix proxy settings before validating the API key." };
+      setApiKeyStatus(status);
+      enqueueToast({
+        id: `settings-api-key-${Date.now()}`,
+        title: status.message,
+        tone: "error",
+      });
+      return;
+    }
+
+    if (trimmedKey.length === 0) {
+      const status = { tone: "info" as const, message: "API key will be cleared after saving settings." };
+      setApiKeyStatus(status);
+      enqueueToast({
+        id: `settings-api-key-${Date.now()}`,
+        title: status.message,
+        tone: "info",
+      });
+      return;
+    }
+
     setIsValidatingKey(true);
     setApiKeyStatus(null);
 
-    await new Promise((resolve) => window.setTimeout(resolve, 180));
-
-    const trimmedKey = values.wallhavenKey.trim();
-    const status =
-      trimmedKey.length === 0
-        ? { tone: "success" as const, message: "API key cleared" }
-        : trimmedKey.length >= 10
-          ? { tone: "success" as const, message: "API key validated" }
-          : { tone: "error" as const, message: "Invalid or expired key" };
-
-    setApiKeyStatus(status);
-    setIsValidatingKey(false);
-    enqueueToast({
-      id: `settings-api-key-${Date.now()}`,
-      title: status.message,
-      tone: status.tone === "error" ? "error" : "success",
-    });
+    try {
+      const diagnostic = await diagnoseWallhavenAccess({
+        wallhavenKey: trimmedKey,
+        networkProxyScheme: values.networkProxyScheme,
+        networkProxyAddress: trimmedProxyAddress,
+      });
+      const status = {
+        tone: "success" as const,
+        message: diagnostic.usesProxy
+          ? "Wallhaven accepted the request with this API key through the configured proxy."
+          : "Wallhaven accepted the request with this API key.",
+      };
+      setApiKeyStatus(status);
+      enqueueToast({
+        id: `settings-api-key-${Date.now()}`,
+        title: "API key checked",
+        description: status.message,
+        tone: "success",
+      });
+    } catch (error) {
+      const message = getErrorMessage(error, "Unable to validate the API key against Wallhaven.");
+      setApiKeyStatus({ tone: "error", message });
+      enqueueToast({
+        id: `settings-api-key-${Date.now()}`,
+        title: "API key check failed",
+        description: message,
+        tone: "error",
+      });
+    } finally {
+      setIsValidatingKey(false);
+    }
   };
 
   const testProxy = async () => {
+    if (proxyAddressError) {
+      const status = { tone: "error" as const, message: "Fix proxy settings before testing connectivity." };
+      setProxyStatus(status);
+      enqueueToast({
+        id: `settings-proxy-${Date.now()}`,
+        title: status.message,
+        tone: "error",
+      });
+      return;
+    }
+
     setIsTestingProxy(true);
     setProxyStatus(null);
 
-    await new Promise((resolve) => window.setTimeout(resolve, 180));
-
-    const status =
-      trimmedProxyAddress.length === 0
-        ? { tone: "success" as const, message: "Direct connection ready" }
-        : proxyAddressError
-          ? { tone: "error" as const, message: "Proxy unavailable" }
-          : { tone: "success" as const, message: "Proxy test passed" };
-
-    setProxyStatus(status);
-    setIsTestingProxy(false);
-    enqueueToast({
-      id: `settings-proxy-${Date.now()}`,
-      title: status.message,
-      tone: status.tone === "error" ? "error" : "success",
-    });
+    try {
+      const diagnostic = await diagnoseWallhavenAccess({
+        networkProxyScheme: values.networkProxyScheme,
+        networkProxyAddress: trimmedProxyAddress,
+      });
+      const status = {
+        tone: "success" as const,
+        message: diagnostic.usesProxy
+          ? `${proxyLabels[values.networkProxyScheme]} proxy reached Wallhaven.`
+          : "Direct Wallhaven connection succeeded.",
+      };
+      setProxyStatus(status);
+      enqueueToast({
+        id: `settings-proxy-${Date.now()}`,
+        title: "Connectivity checked",
+        description: status.message,
+        tone: "success",
+      });
+    } catch (error) {
+      const message = getErrorMessage(error, "Unable to reach Wallhaven with the current network settings.");
+      setProxyStatus({ tone: "error", message });
+      enqueueToast({
+        id: `settings-proxy-${Date.now()}`,
+        title: "Connectivity check failed",
+        description: message,
+        tone: "error",
+      });
+    } finally {
+      setIsTestingProxy(false);
+    }
   };
 
-  const clearCache = () => {
+  const resetCacheEstimate = () => {
     setConfirm({
-      title: "Clear cache?",
-      description: "Only generated cache files will be cleared. Downloaded wallpaper originals stay in place.",
-      confirmLabel: "Clear cache",
+      title: "Reset cache estimate?",
+      description: "No cache deletion command exists yet. This only resets the displayed cache estimate; downloaded wallpaper originals stay in place.",
+      confirmLabel: "Reset estimate",
       onConfirm: () => {
-        setIsClearingCache(true);
-        window.setTimeout(() => {
-          setValue("cacheSizeBytes", 0, { shouldDirty: true, shouldTouch: true });
-          setIsClearingCache(false);
-          enqueueToast({
-            id: `settings-cache-${Date.now()}`,
-            title: "Cache cleaned",
-            description: "Downloaded wallpaper originals were not removed.",
-            tone: "success",
-          });
-        }, 240);
+        setIsResettingCacheEstimate(true);
+        setValue("cacheSizeBytes", 0, { shouldDirty: true, shouldTouch: true });
+        setIsResettingCacheEstimate(false);
+        enqueueToast({
+          id: `settings-cache-${Date.now()}`,
+          title: "Cache estimate reset",
+          description: "No downloaded wallpaper originals were removed.",
+          tone: "success",
+        });
       },
     });
   };
@@ -551,9 +616,9 @@ export function SettingsPage() {
               </p>
             </div>
 
-            <div className="grid grid-cols-1 items-center gap-3 md:grid-cols-[124px_194px_minmax(0,1fr)_116px] md:gap-4">
+            <div className="grid grid-cols-1 items-center gap-3 md:grid-cols-[124px_244px_minmax(0,1fr)_116px] md:gap-4">
               <span className="text-[13px] font-semibold text-foreground">Protocol</span>
-              <div className="wh-control grid h-[42px] grid-cols-2 overflow-hidden p-0">
+              <div className="wh-control grid h-[42px] grid-cols-3 overflow-hidden p-0">
                 {proxyOptions.map((option) => (
                   <button
                     aria-pressed={values.networkProxyScheme === option.value}
@@ -604,11 +669,11 @@ export function SettingsPage() {
                 <h3 className="text-[20px] font-semibold leading-7 text-foreground" id="advanced-heading">
                   Advanced
                 </h3>
-                <p className="text-[13px] leading-6 text-muted-foreground">Desktop startup, deletion prompts, telemetry, and cache cleanup.</p>
+                <p className="text-[13px] leading-6 text-muted-foreground">Desktop startup, deletion prompts, telemetry, and the local cache estimate.</p>
               </div>
-              <Button className="h-10 rounded-[14px]" disabled={isClearingCache} onClick={clearCache} type="button" variant="outline">
-                {isClearingCache ? <Spinner /> : <Trash2 className="h-4 w-4" />}
-                Clear cache
+              <Button className="h-10 rounded-[14px]" disabled={isResettingCacheEstimate} onClick={resetCacheEstimate} type="button" variant="outline">
+                {isResettingCacheEstimate ? <Spinner /> : <RefreshCcw className="h-4 w-4" />}
+                Reset cache meter
               </Button>
             </div>
 
@@ -683,7 +748,7 @@ export function SettingsPage() {
                 ["Default app directory", effectiveDestination.defaultDirectoryPath],
                 ["Gallery compatibility", "Existing SQLite records keep their saved relative and absolute file paths."],
                 ["Proxy", effectiveDestination.proxyLabel],
-                ["Cache", `${formatBytes(values.cacheSizeBytes)} · cleaning never removes downloaded wallpaper originals.`],
+                ["Cache", `${formatBytes(values.cacheSizeBytes)} · meter reset never removes downloaded wallpaper originals.`],
                 ["Security", "API key is masked in UI. Prefer OS secure storage when the plugin is available; Tauri Store fallback is explicit."],
               ].map(([label, value]) => (
                 <div className="rounded-[16px] border border-border bg-[var(--surface-deep)] px-4 py-4" key={label}>

--- a/src/features/shell/ui-shell-store.ts
+++ b/src/features/shell/ui-shell-store.ts
@@ -1,6 +1,8 @@
 import { create } from "zustand";
 
 export type GalleryView = "grid" | "timeline" | "list" | "compact";
+export type GalleryCollectionShortcut = "Favorites" | "4K Ultra" | "Nature" | "Anime" | "Space";
+export type ShellPanel = "quick-navigation" | "help";
 
 export type DownloadSummary = {
   activeCount: number;
@@ -25,21 +27,30 @@ export type ConfirmState = {
   onCancel?: () => void;
 };
 
+export type GalleryCollectionRequest = {
+  label: GalleryCollectionShortcut;
+  requestId: number;
+};
+
 type UiShellState = {
   globalQuery: string;
   selectedSearchIds: string[];
   galleryView: GalleryView;
+  galleryCollectionRequest: GalleryCollectionRequest | null;
   downloadSummary: DownloadSummary;
   toasts: ShellToast[];
   confirm: ConfirmState | null;
+  activeShellPanel: ShellPanel | null;
   setGlobalQuery: (value: string) => void;
   setSelectedSearchIds: (ids: string[]) => void;
   clearSelectedSearchIds: () => void;
   setGalleryView: (view: GalleryView) => void;
+  requestGalleryCollection: (label: GalleryCollectionShortcut) => void;
   setDownloadSummary: (summary: DownloadSummary) => void;
   enqueueToast: (toast: ShellToast) => void;
   dismissToast: (id: string) => void;
   setConfirm: (confirm: ConfirmState | null) => void;
+  setActiveShellPanel: (panel: ShellPanel | null) => void;
 };
 
 export const defaultDownloadSummary: DownloadSummary = {
@@ -52,9 +63,11 @@ export const useUiShellStore = create<UiShellState>((set) => ({
   globalQuery: "",
   selectedSearchIds: [],
   galleryView: "grid",
+  galleryCollectionRequest: null,
   downloadSummary: { ...defaultDownloadSummary },
   toasts: [],
   confirm: null,
+  activeShellPanel: null,
   setGlobalQuery: (value) => {
     set({ globalQuery: value });
   },
@@ -66,6 +79,14 @@ export const useUiShellStore = create<UiShellState>((set) => ({
   },
   setGalleryView: (view) => {
     set({ galleryView: view });
+  },
+  requestGalleryCollection: (label) => {
+    set((state) => ({
+      galleryCollectionRequest: {
+        label,
+        requestId: (state.galleryCollectionRequest?.requestId ?? 0) + 1,
+      },
+    }));
   },
   setDownloadSummary: (summary) => {
     set({ downloadSummary: { ...summary } });
@@ -82,5 +103,8 @@ export const useUiShellStore = create<UiShellState>((set) => ({
   },
   setConfirm: (confirm) => {
     set({ confirm });
+  },
+  setActiveShellPanel: (panel) => {
+    set({ activeShellPanel: panel });
   },
 }));

--- a/src/infrastructure/tauri/search-contract.test.ts
+++ b/src/infrastructure/tauri/search-contract.test.ts
@@ -13,6 +13,8 @@ describe("buildSearchWallpapersCommandPayload", () => {
       topRange: "1M",
       q: "landscape",
       page: 2,
+      atLeast: "1920x1080",
+      ratios: "16x9,16x10",
     } as const;
 
     const commandPayload = buildSearchWallpapersCommandPayload(filters, {
@@ -26,6 +28,8 @@ describe("buildSearchWallpapersCommandPayload", () => {
       topRange: "1M",
       q: "landscape",
       page: 2,
+      atLeast: "1920x1080",
+      ratios: "16x9,16x10",
       apiKey: "test-key",
     });
 

--- a/src/infrastructure/tauri/search-contract.ts
+++ b/src/infrastructure/tauri/search-contract.ts
@@ -11,6 +11,8 @@ interface SearchWallpapersCommandPayloadBase {
   purity?: WallhavenPurityFilter;
   q?: string;
   page?: number;
+  atLeast?: string;
+  ratios?: string;
   apiKey?: string;
 }
 
@@ -59,6 +61,14 @@ function buildCommandPayloadBase(
 
   if (filters.page !== undefined) {
     payload.page = filters.page;
+  }
+
+  if (filters.atLeast !== undefined) {
+    payload.atLeast = filters.atLeast;
+  }
+
+  if (filters.ratios !== undefined) {
+    payload.ratios = filters.ratios;
   }
 
   const apiKey = normalizeApiKey(options.apiKey);

--- a/src/infrastructure/tauri/search-contract.typecheck.ts
+++ b/src/infrastructure/tauri/search-contract.typecheck.ts
@@ -7,6 +7,8 @@ export const validToplistCommandPayload: SearchWallpapersCommandPayload = {
   topRange: "1M",
   q: "landscape",
   page: 2,
+  atLeast: "1920x1080",
+  ratios: "16x9",
   apiKey: "test-key",
 };
 

--- a/src/infrastructure/tauri/settings-repository.test.ts
+++ b/src/infrastructure/tauri/settings-repository.test.ts
@@ -14,6 +14,7 @@ import { Store } from "@tauri-apps/plugin-store";
 import { SettingsCommandError } from "@/application/settings/settings.types";
 
 import {
+  diagnoseWallhavenAccess,
   loadDownloadDirectorySettings,
   loadNetworkProxySettings,
   loadStoredWallhavenKey,
@@ -194,6 +195,38 @@ describe("settings-repository", () => {
     expect(invoke).toHaveBeenCalledWith("save_network_proxy_settings", {
       request: {
         proxy: null,
+      },
+    });
+  });
+
+  it("invokes the Wallhaven access diagnostic command with unsaved proxy and API key input", async () => {
+    vi.mocked(invoke).mockResolvedValue({
+      usesProxy: true,
+      authenticated: true,
+      total: 42,
+    });
+
+    await expect(
+      diagnoseWallhavenAccess({
+        apiKey: "test-key",
+        proxy: {
+          scheme: "socks5",
+          address: "127.0.0.1:7897",
+        },
+      }),
+    ).resolves.toEqual({
+      usesProxy: true,
+      authenticated: true,
+      total: 42,
+    });
+
+    expect(invoke).toHaveBeenCalledWith("diagnose_wallhaven_access", {
+      request: {
+        apiKey: "test-key",
+        proxy: {
+          scheme: "socks5",
+          address: "127.0.0.1:7897",
+        },
       },
     });
   });

--- a/src/infrastructure/tauri/settings-repository.ts
+++ b/src/infrastructure/tauri/settings-repository.ts
@@ -6,6 +6,7 @@ import type {
   NetworkProxySettings,
   SettingsCommandError,
   SettingsPreferences,
+  WallhavenAccessDiagnostic,
 } from "@/application/settings/settings.types";
 import { toSettingsCommandError } from "@/application/settings/settings.types";
 
@@ -17,6 +18,11 @@ export const defaultSettingsPreferences: SettingsPreferences = {
   confirmBeforeDelete: true,
   telemetryEnabled: false,
   cacheSizeBytes: 38_400_000,
+};
+
+type DiagnoseWallhavenAccessCommandRequest = {
+  proxy: NetworkProxySettings | null;
+  apiKey?: string;
 };
 
 async function withSettingsStore<T>(callback: (store: Store) => Promise<T>): Promise<T> {
@@ -132,6 +138,18 @@ export async function saveNetworkProxySettings(
       request: {
         proxy,
       },
+    });
+  } catch (error) {
+    throw toSettingsCommandError(error) as SettingsCommandError;
+  }
+}
+
+export async function diagnoseWallhavenAccess(
+  request: DiagnoseWallhavenAccessCommandRequest,
+): Promise<WallhavenAccessDiagnostic> {
+  try {
+    return await invoke<WallhavenAccessDiagnostic>("diagnose_wallhaven_access", {
+      request,
     });
   } catch (error) {
     throw toSettingsCommandError(error) as SettingsCommandError;


### PR DESCRIPTION
## Summary
- Wire top chrome quick navigation/help panels and sidebar gallery collection shortcuts.
- Add real search resolution/aspect-ratio filters through the TypeScript and Rust query contracts.
- Keep Gallery defaulted to SFW while collection shortcuts and timeline group filters work.
- Replace placeholder download pause/save controls with bounded actions that match current backend capabilities.
- Replace simulated settings API-key/proxy checks with a Tauri Wallhaven access diagnostic and clarify that cache reset only resets the displayed estimate.

## Verification
- git diff --check
- cargo test --manifest-path src-tauri/Cargo.toml settings
- PATH="/Applications/Codex.app/Contents/Resources:$PWD/node_modules/.bin:$PATH" tsc -b

## Not run
- Vitest target suite could not start under Codex App bundled Node because macOS rejected the rolldown native binding code signature.

## Notes
- Backend collection persistence, pause/resume download commands, and a real cache deletion command do not exist yet, so this avoids presenting those as durable actions.
